### PR TITLE
Updated the labels to match the new results output format. Added power.cfg path to sim.cfg.

### DIFF
--- a/other/noxim_explorer.cpp
+++ b/other/noxim_explorer.cpp
@@ -29,8 +29,8 @@ using namespace std;
 #define RPACKETS_LABEL       "% Total received packets:"
 #define RFLITS_LABEL         "% Total received flits:"
 #define AVG_DELAY_LABEL      "% Global average delay (cycles):"
-#define AVG_THROUGHPUT_LABEL "% Global average throughput (flits/cycle):"
-#define THROUGHPUT_LABEL     "% Throughput (flits/cycle/IP):"
+#define AVG_THROUGHPUT_LABEL "% Network throughput (flits/cycle):"
+#define THROUGHPUT_LABEL     "% Average IP throughput (flits/cycle/IP):"
 #define MAX_DELAY_LABEL      "% Max delay (cycles):"
 #define TOTAL_ENERGY_LABEL   "% Total energy (J):"
 

--- a/other/sim.cfg
+++ b/other/sim.cfg
@@ -15,7 +15,8 @@
    -warmup 2000
    -size 8 8
    -buffer 4
-   -config ../config_examples/default_config.yaml 
+   -config ../config_examples/default_config.yaml
+   -power ../bin/power.yaml
 [/default]
 
 [aggregation]


### PR DESCRIPTION
Updated the labels to match the new results output format. (fixes "Output file <filename> corrupted" error).

Added default power.yaml file path to the default sim.cfg file, so that it works without any edits.