### PR TITLE
Add Docker support

### DIFF
--- a/other/setup/Dockerfile
+++ b/other/setup/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y apt-utils && apt-get install -y \
+    sudo \
+    software-properties-common \
+    wget
+RUN cd /opt && \
+    bash -c 'bash <(wget -qO- https://raw.githubusercontent.com/davidepatti/noxim/master/other/setup/ubuntu.sh)'

--- a/other/setup/ubuntu.sh
+++ b/other/setup/ubuntu.sh
@@ -5,7 +5,7 @@ set -e
 export GIT_SSL_NO_VERIFY=1
 
 sudo apt-get update
-sudo apt-get -y install build-essential linux-headers-$(uname -r) wget tar libboost-dev cmake 
+sudo apt-get -y install build-essential linux-headers-generic wget tar libboost-dev cmake
 
 if [ $(dpkg -s git 2>/dev/null | grep "ok installed" | wc -l) -eq 0 ]
 then 

--- a/other/setup/ubuntu.sh
+++ b/other/setup/ubuntu.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 export GIT_SSL_NO_VERIFY=1
 
 sudo apt-get update


### PR DESCRIPTION
As discussed with @smonteleone at ICCD'18, this PR allows to install and run Noxim on any computer that can run Docker.

Build a Docker image for Noxim on your machine and create a container named `noxim`:
```sh
docker build -t noxim https://raw.githubusercontent.com/davidepatti/noxim/master/other/setup/Dockerfile
docker create --name noxim -it noxim
```

Then, whenever you want to run Noxim (modifications to configuration and sources are persisted inside that container):
```sh
docker run -ai noxim
```

You may want to add this to the README.

Thanks for creating and maintaining Noxim!