### PR TITLE
macOS installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ If you are working on Ubuntu, you can install noxim and all the dependencies wit
 
     bash <(wget -qO- --no-check-certificate https://raw.githubusercontent.com/davidepatti/noxim/master/other/setup/ubuntu.sh)
 
+Similarly for macOS:
+
+    /bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/davidepatti/noxim/master/other/setup/macos.zsh)"
+
 Or, to get just the latest master sources, you can run:
 
     git clone https://github.com/davidepatti/noxim.git

--- a/other/setup/macos.zsh
+++ b/other/setup/macos.zsh
@@ -1,0 +1,151 @@
+#!/bin/zsh
+
+set -e
+
+# print colours
+RED='\u001b[31m'
+GREEN='\u001b[32m'
+MAGENTA='\u001b[35m'
+RESET='\u001b[0m'
+
+# only actually try to run on macOS
+if [[ $OSTYPE == 'darwin'* ]]; then
+
+    echo -e $MAGENTA"\n'noxim' installation script for macOS"$RESET
+    echo -e "noxim will be installed at `pwd`"
+    echo -e "Begin? [y/n]"
+    read -sk 1 RESPONSE
+
+    if [[ ! $RESPONSE =~ ^[Yy]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+    echo
+ 
+    # make sure required commands exist
+    REQUIRED_COMMANDS=(git cmake make curl tar gcc g++)  
+
+    echo -e $MAGENTA"Checking for required executables:"$RESET
+
+    for CMD in $REQUIRED_COMMANDS
+    do
+        if ! command -v $CMD > /dev/null; then
+            echo -e $RED"Error: $CMD not found"$RESET
+            exit 1
+        else 
+            echo -e " - $CMD"
+        fi
+    done
+    echo
+
+    # check if noxim already downloaded
+    # -> try to update if it does
+    # -> clone if not
+    echo -e $MAGENTA"Downloading noxim..."$RESET
+    if [ -d "./noxim" ]; then
+        echo -e $GREEN"noxim repository already exists."$RESET
+        echo "Pulling from origin..."
+        cd noxim 
+        git pull
+        cd bin
+    else 
+        git clone https://github.com/davidepatti/noxim > /dev/null
+        echo -e $GREEN"noxim downloaded."$RESET
+        cd noxim/bin
+    fi
+    echo
+
+    # libs directory
+    mkdir -p libs
+    cd libs
+
+    # yaml download
+    echo -e $MAGENTA"Downloading yaml-cpp..."$RESET
+    if [ ! -d "./yaml-cpp" ]; then
+        git clone https://github.com/jbeder/yaml-cpp
+        echo -e $GREEN"yaml-cpp downloaded.\n"$RESET
+    else 
+        echo -e $GREEN"yaml-cpp already downloaded.\n"$RESET
+    fi
+
+    # yaml build
+    echo -e $MAGENTA"Building yaml-cpp..."$RESET
+    cd yaml-cpp/
+
+    if [ "`git branch --list r0.6.0`" ]; then
+        git checkout r0.6.0
+    else 
+        git checkout -b r0.6.0 yaml-cpp-0.6.0
+    fi
+
+    mkdir -p lib
+    cd lib
+    cmake ..
+    make
+    cd ../..
+    echo -e $GREEN"Installed yaml-cpp successfully\n"$RESET
+
+    # systemc download
+    echo -e $MAGENTA"Downloading SystemC..."$RESET
+    SYSTEMC_VERSION=systemc-2.3.1
+    SYSTEMC_VERSION_SUFFIX=a
+
+    if [ ! -d "./$SYSTEMC_VERSION" ]; then
+
+        # download archive
+        if [ ! -f "./$SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz" ]; then
+            curl -O https://www.accellera.org/images/downloads/standards/systemc/$SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz &> /dev/null
+        fi
+        
+        # extract archive
+        tar -xf $SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz $SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX
+        rm $SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz
+
+        # rename removing suffix for compatibility with makefile
+        mv $SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX $SYSTEMC_VERSION
+        echo -e $GREEN"SystemC downloaded.\n"$RESET
+
+    else 
+        echo -e $GREEN"SystemC already downloaded.\n"$RESET
+    fi
+
+    cd $SYSTEMC_VERSION
+
+    # pre-build hack for ARM Macs
+    # see: https://forums.accellera.org/topic/6984-running-systemc-on-new-apple-m1-silicon/
+    if [[ $(uname -m) == 'arm64' ]]; then
+        if ! grep -q arm64 configure; then
+            sed -i '' '4618i\
+            arm)\
+                TARGET_ARCH=\"macosarm\"\
+                CPU_ARCH="arm64"\
+                QT_ARCH="pthreads"\
+                ;;\
+            ' configure
+        fi
+    fi
+
+    # systemc build
+    echo -e $MAGENTA"Building SystemC..."$RESET
+    mkdir -p objdir
+    cd objdir 
+
+    export CXX=g++
+    export CC=gcc
+    ../configure 
+    make 
+    make install 
+
+    echo -e $GREEN"SystemC built successfully.\n"$RESET 
+    cd ..
+
+    # make noxim
+    echo -e $MAGENTA"Building noxim..."$RESET
+    cd ../..
+    make
+    echo -e $GREEN"Done.\n"$RESET
+
+else
+    echo -e $RED"Error: not macOS!"$RESET
+    exit 1
+fi

--- a/other/setup/macos.zsh
+++ b/other/setup/macos.zsh
@@ -49,7 +49,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         git pull
         cd bin
     else 
-        git clone https://github.com/davidepatti/noxim > /dev/null
+        git clone https://github.com/davidepatti/noxim
         echo -e $GREEN"noxim downloaded."$RESET
         cd noxim/bin
     fi
@@ -94,7 +94,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
 
         # download archive
         if [ ! -f "./$SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz" ]; then
-            curl -O https://www.accellera.org/images/downloads/standards/systemc/$SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz &> /dev/null
+            curl -O https://www.accellera.org/images/downloads/standards/systemc/$SYSTEMC_VERSION$SYSTEMC_VERSION_SUFFIX.tar.gz
         fi
         
         # extract archive

--- a/other/setup/macos.zsh
+++ b/other/setup/macos.zsh
@@ -1,5 +1,15 @@
 #!/bin/zsh
 
+###############################################################################
+#               :
+#   File        :   macos.zsh
+#               :
+#   Author(s)   :   Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+#               :
+#   Description :   macOS installer script for noxim
+#               :
+###############################################################################
+
 set -e
 
 # print colours


### PR DESCRIPTION
### Comments
- Noxim installer script for macOS.
- Works in a similar way to the existing `ubuntu.sh` with a few extra steps.
- Tested on an ARM MacBook, should also work for Intel.
- Hopefully this is helpful for others working on macOS!

### Dependencies
- Requires `git`, `make`, `cmake`, `gcc` and `g++` to be installed already.
- No dependency on package managers (Homebrew, MacPorts, etc).

### Usage
After merging to `davidepatti:master`:
```sh
/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/davidepatti/noxim/master/other/setup/macos.zsh)"
```
At the moment on `t-bre:master`:
```sh
/bin/zsh -c "$(curl -fsSL https://raw.githubusercontent.com/t-bre/noxim/master/other/setup/macos.zsh)"
```