### PR TITLE
Fix hotspot percentage check

### DIFF
--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -382,7 +382,7 @@ void checkConfiguration()
 	}
 
 	if (GlobalParams::hotspots[i].second < 0.0
-	    && GlobalParams::hotspots[i].second > 1.0) {
+	    || GlobalParams::hotspots[i].second > 1.0) {
 	    cerr <<
 		"Error: hotspot percentage must be in the interval [0,1]"
 		<< endl;


### PR DESCRIPTION
Noticed that adding hotspots on the command line with invalid percentages outside [0, 1] won't throw an error as it should. Changed an `&&` to an `||` in the configuration checks to fix this.