### PR TITLE
fix: use cmake --build for macOS install script

### DIFF
--- a/other/setup/macos.zsh
+++ b/other/setup/macos.zsh
@@ -5,6 +5,7 @@
 #   File        :   macos.zsh
 #               :
 #   Author(s)   :   Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+#               :   George Peppard (@inventor02, gjp1g21@soton.ac.uk)
 #               :
 #   Description :   macOS installer script for noxim
 #               :
@@ -91,7 +92,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     mkdir -p lib
     cd lib
     cmake ..
-    make
+    cmake --build .
     cd ../..
     echo -e $GREEN"Installed yaml-cpp successfully\n"$RESET
 


### PR DESCRIPTION
If the `CMAKE_GENERATOR` is set to anything other than `Unix Makefiles`, the macOS install script fails, as it is hardcoded to use `make` regardless of the CMake setting.

CMake has a solution for this in the form of `cmake --build`, which uses the generator that was used when CMake was executed.

This PR implements this for the yaml-cpp build; the rest of the components do not use CMake and are provided with Makefiles, so work correctly.

(aside: I happen to know the person who wrote the original script - it is a small world!)