### PR TITLE
[WIP] Support hardcoded traffic patterns

### DIFF
--- a/config_examples/256_12h.yaml
+++ b/config_examples/256_12h.yaml
@@ -178,7 +178,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/256_12h.yaml
+++ b/config_examples/256_12h.yaml
@@ -185,4 +185,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/256_16h.yaml
+++ b/config_examples/256_16h.yaml
@@ -200,4 +200,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/256_16h.yaml
+++ b/config_examples/256_16h.yaml
@@ -193,7 +193,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/256_16h_4channels.yaml
+++ b/config_examples/256_16h_4channels.yaml
@@ -200,4 +200,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/256_16h_4channels.yaml
+++ b/config_examples/256_16h_4channels.yaml
@@ -193,7 +193,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/256_4h.yaml
+++ b/config_examples/256_4h.yaml
@@ -159,4 +159,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/256_4h.yaml
+++ b/config_examples/256_4h.yaml
@@ -152,7 +152,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/256_4h_2channels.yaml
+++ b/config_examples/256_4h_2channels.yaml
@@ -159,4 +159,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/256_4h_2channels.yaml
+++ b/config_examples/256_4h_2channels.yaml
@@ -152,7 +152,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/256_8h.yaml
+++ b/config_examples/256_8h.yaml
@@ -174,4 +174,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/256_8h.yaml
+++ b/config_examples/256_8h.yaml
@@ -167,7 +167,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/article.yaml
+++ b/config_examples/article.yaml
@@ -428,4 +428,4 @@ traffic_distribution: TRAFFIC_TABLE_BASED
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/article.yaml
+++ b/config_examples/article.yaml
@@ -421,7 +421,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_TABLE_BASED
 # when traffic table base specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/configWirelessCore2CoreBfly.yaml
+++ b/config_examples/configWirelessCore2CoreBfly.yaml
@@ -160,4 +160,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/configWirelessCore2CoreBfly.yaml
+++ b/config_examples/configWirelessCore2CoreBfly.yaml
@@ -153,7 +153,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_config.yaml
+++ b/config_examples/default_config.yaml
@@ -167,4 +167,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/default_config.yaml
+++ b/config_examples/default_config.yaml
@@ -160,7 +160,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_configBaseline.yaml
+++ b/config_examples/default_configBaseline.yaml
@@ -149,7 +149,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_configBaseline.yaml
+++ b/config_examples/default_configBaseline.yaml
@@ -156,4 +156,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/default_configBfly.yaml
+++ b/config_examples/default_configBfly.yaml
@@ -149,7 +149,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_configBfly.yaml
+++ b/config_examples/default_configBfly.yaml
@@ -156,4 +156,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/default_configMesh.yaml
+++ b/config_examples/default_configMesh.yaml
@@ -167,4 +167,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/default_configMesh.yaml
+++ b/config_examples/default_configMesh.yaml
@@ -160,7 +160,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_configMeshNoHUB.yaml
+++ b/config_examples/default_configMeshNoHUB.yaml
@@ -167,4 +167,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/default_configMeshNoHUB.yaml
+++ b/config_examples/default_configMeshNoHUB.yaml
@@ -160,7 +160,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_configOmega.yaml
+++ b/config_examples/default_configOmega.yaml
@@ -147,7 +147,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/default_configOmega.yaml
+++ b/config_examples/default_configOmega.yaml
@@ -154,4 +154,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/multi_channel.yaml
+++ b/config_examples/multi_channel.yaml
@@ -159,7 +159,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/multi_channel.yaml
+++ b/config_examples/multi_channel.yaml
@@ -166,4 +166,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/testdelta.yaml
+++ b/config_examples/testdelta.yaml
@@ -116,4 +116,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/testdelta.yaml
+++ b/config_examples/testdelta.yaml
@@ -109,7 +109,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/testdelta_hops_1.yaml
+++ b/config_examples/testdelta_hops_1.yaml
@@ -115,7 +115,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/testdelta_hops_1.yaml
+++ b/config_examples/testdelta_hops_1.yaml
@@ -122,4 +122,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/testdelta_hops_16.yaml
+++ b/config_examples/testdelta_hops_16.yaml
@@ -117,7 +117,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/testdelta_hops_16.yaml
+++ b/config_examples/testdelta_hops_16.yaml
@@ -124,4 +124,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/config_examples/testdelta_hops_2.yaml
+++ b/config_examples/testdelta_hops_2.yaml
@@ -117,7 +117,11 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_BIT_REVERSAL
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
 traffic_distribution: TRAFFIC_RANDOM
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt

--- a/config_examples/testdelta_hops_2.yaml
+++ b/config_examples/testdelta_hops_2.yaml
@@ -124,4 +124,4 @@ traffic_distribution: TRAFFIC_RANDOM
 traffic_table_filename: "t.txt"
 # when hardcoded traffic pattern is specified, use the following
 # configuration file
-traffic_hardcoded_filename: "t.txt
+traffic_hardcoded_filename: "t.txt"

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -60,13 +60,14 @@ where [options] is one or more of the following ones:
 		pareto on off r	Self-similar Pareto distribution with given real parameters (alfa-on alfa-off r)
 		custom R	Custom distribution with given real probability of retransmission
 	-traffic TYPE	Set the spatial distribution of traffic to TYPE where TYPE is one of the following (default 0'):
-		random		Random traffic distribution
-		transpose1	Transpose matrix 1 traffic distribution
-		transpose2	Transpose matrix 2 traffic distribution
-		bitreversal	Bit-reversal traffic distribution
-		butterfly	Butterfly traffic distribution
-		shuffle		Shuffle traffic distribution
-		table FILENAME	Traffic Table Based traffic distribution with table in the specified file
+		random		   Random traffic distribution
+		transpose1	   Transpose matrix 1 traffic distribution
+		transpose2	   Transpose matrix 2 traffic distribution
+		bitreversal	   Bit-reversal traffic distribution
+		butterfly	   Butterfly traffic distribution
+		shuffle		   Shuffle traffic distribution
+		table FILENAME	   Traffic Table Based traffic distribution with table in the specified file
+		hardcoded FILENAME Hardcoded traffic patterns with individual packets in the specified file
 	-hs ID P	Add node ID to hotspot nodes, with percentage P (0..1) (Only for 'random' traffic)
 	-pwr FILENAME	Router and link power data (default default_router.pwr)
 	-lpls		Enable low power link strategy (default 0)

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -60,14 +60,14 @@ where [options] is one or more of the following ones:
 		pareto on off r	Self-similar Pareto distribution with given real parameters (alfa-on alfa-off r)
 		custom R	Custom distribution with given real probability of retransmission
 	-traffic TYPE	Set the spatial distribution of traffic to TYPE where TYPE is one of the following (default 0'):
-		random		   Random traffic distribution
-		transpose1	   Transpose matrix 1 traffic distribution
-		transpose2	   Transpose matrix 2 traffic distribution
-		bitreversal	   Bit-reversal traffic distribution
-		butterfly	   Butterfly traffic distribution
-		shuffle		   Shuffle traffic distribution
-		table FILENAME	   Traffic Table Based traffic distribution with table in the specified file
-		hardcoded FILENAME Hardcoded traffic patterns with individual packets in the specified file
+                random             Random traffic distribution
+                transpose1         Transpose matrix 1 traffic distribution
+                transpose2         Transpose matrix 2 traffic distribution
+                bitreversal        Bit-reversal traffic distribution
+                butterfly          Butterfly traffic distribution
+                shuffle            Shuffle traffic distribution
+                table FILENAME     Traffic Table Based traffic distribution with table in the specified file
+                hardcoded FILENAME Hardcoded traffic patterns with individual packets in the specified file
 	-hs ID P	Add node ID to hotspot nodes, with percentage P (0..1) (Only for 'random' traffic)
 	-pwr FILENAME	Router and link power data (default default_router.pwr)
 	-lpls		Enable low power link strategy (default 0)

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -78,6 +78,7 @@ void loadConfiguration() {
     GlobalParams::probability_of_retransmission = readParam<double>(config, "probability_of_retransmission");
     GlobalParams::traffic_distribution = readParam<string>(config, "traffic_distribution");
     GlobalParams::traffic_table_filename = readParam<string>(config, "traffic_table_filename");
+    GlobalParams::traffic_hardcoded_filename = readParam<string>(config, "traffic_hardcoded_filename");
     GlobalParams::clock_period_ps = readParam<int>(config, "clock_period_ps");
     GlobalParams::simulation_time = readParam<int>(config, "simulation_time");
     GlobalParams::n_virtual_channels = readParam<int>(config, "n_virtual_channels");
@@ -573,6 +574,10 @@ void parseCmdLine(int arg_num, char *arg_vet[])
 		    GlobalParams::traffic_distribution =
 			TRAFFIC_TABLE_BASED;
 		    GlobalParams::traffic_table_filename = arg_vet[++i];
+		} else if (!strcmp(traffic, "hardcoded")) {
+		    GlobalParams::traffic_distribution =
+			TRAFFIC_HARDCODED;
+		    GlobalParams::traffic_hardcoded_filename = arg_vet[++i];
 		} else if (!strcmp(traffic, "local")) {
 		    GlobalParams::traffic_distribution = TRAFFIC_LOCAL;
 		    GlobalParams::locality=atof(arg_vet[++i]);

--- a/src/GlobalParams.cpp
+++ b/src/GlobalParams.cpp
@@ -35,6 +35,7 @@ double GlobalParams::probability_of_retransmission;
 double GlobalParams::locality;
 string GlobalParams::traffic_distribution;
 string GlobalParams::traffic_table_filename;
+string GlobalParams::traffic_hardcoded_filename;
 string GlobalParams::config_filename;
 string GlobalParams::power_config_filename;
 int GlobalParams::clock_period_ps;

--- a/src/GlobalParams.h
+++ b/src/GlobalParams.h
@@ -74,6 +74,7 @@ using namespace std;
 #define TRAFFIC_BUTTERFLY      "TRAFFIC_BUTTERFLY"
 #define TRAFFIC_LOCAL	       "TRAFFIC_LOCAL"
 #define TRAFFIC_ULOCAL	       "TRAFFIC_ULOCAL"
+#define TRAFFIC_HARDCODED      "TRAFFIC_HARDCODED"
 
 // Verbosity levels
 #define VERBOSE_OFF            "VERBOSE_OFF"
@@ -160,6 +161,7 @@ struct GlobalParams {
     static double locality;
     static string traffic_distribution;
     static string traffic_table_filename;
+    static string traffic_hardcoded_filename;
     static string config_filename;
     static string power_config_filename;
     static int clock_period_ps;

--- a/src/GlobalTrafficHardcoding.cpp
+++ b/src/GlobalTrafficHardcoding.cpp
@@ -71,3 +71,11 @@ bool GlobalTrafficHardcoding::load(const char *fname)
 
   return true;
 }
+
+vector < HardcodedTrafficEntry > const& GlobalTrafficHardcoding::traffic_at_cycle(int cycle) const {
+  return traffic_list[cycle];
+}
+
+size_t GlobalTrafficHardcoding::num_cycles() const {
+  return traffic_list.size();
+}

--- a/src/GlobalTrafficHardcoding.cpp
+++ b/src/GlobalTrafficHardcoding.cpp
@@ -1,0 +1,73 @@
+/*
+ * Noxim - the NoC Simulator
+ *
+ * (C) 2005-2018 by the University of Catania
+ * For the complete list of authors refer to file ../doc/AUTHORS.txt
+ * For the license applied to these sources refer to file ../doc/LICENSE.txt
+ *
+ * This file contains the implementation of the global traffic hardcoding
+ */
+
+#include "GlobalTrafficHardcoding.h"
+#include <fstream>
+#include <iostream>
+
+using namespace std;
+
+GlobalTrafficHardcoding::GlobalTrafficHardcoding()
+{
+}
+
+bool GlobalTrafficHardcoding::load(const char *fname)
+{
+  // Open file
+  ifstream fin(fname, ios::in);
+  if (!fin)
+    return false;
+
+  // Initialize variables
+  traffic_list.clear();
+  
+  vector<HardcodedTrafficEntry> current_cycle_traffic;
+  
+  // Cycle reading file
+  while (!fin.eof()) {
+    char line[512];
+    fin.getline(line, sizeof(line) - 1);
+
+    if (line[0] != '\0') {
+      // Skip comment lines
+      if (line[0] != '%' && line[0] != '#') {
+        int src, dst;
+        
+        int params = sscanf(line, "%d %d", &src, &dst);
+        
+        if (params == 2) {
+          // Check for end-of-cycle marker
+          if (src == -1) {
+            // End of current cycle - add the accumulated traffic to the list
+            traffic_list.push_back(current_cycle_traffic);
+            current_cycle_traffic.clear();
+          } else {
+            // Valid traffic entry - add to current cycle
+            HardcodedTrafficEntry entry;
+            entry.src = src;
+            entry.dst = dst;
+            current_cycle_traffic.push_back(entry);
+          }
+        } else if (params == 1 && src == -1) {
+          // Single -1 on a line (end of cycle or dead cycle)
+          traffic_list.push_back(current_cycle_traffic);
+          current_cycle_traffic.clear();
+        }
+      }
+    }
+  }
+  
+  // If there's remaining traffic in current_cycle_traffic, add it
+  if (!current_cycle_traffic.empty()) {
+    traffic_list.push_back(current_cycle_traffic);
+  }
+
+  return true;
+}

--- a/src/GlobalTrafficHardcoding.h
+++ b/src/GlobalTrafficHardcoding.h
@@ -33,17 +33,15 @@ class GlobalTrafficHardcoding {
     // Load traffic table from file. Returns true if ok, false otherwise
     bool load(const char *fname);
 
+    vector < HardcodedTrafficEntry > const& traffic_at_cycle(int cycle) const;
+
+    size_t num_cycles() const;
+
   private:
 
-  // Outer vector: Which cycle the traffic occurs at
-  // Inner vector: Attempted packets at given cycle
-  vector < vector < HardcodedTrafficEntry > > traffic_list;
-
-  public:
-
-  vector < HardcodedTrafficEntry > const& traffic_at_cycle(int cycle) const;
-
-  size_t num_cycles() const;
+    // Outer vector: Which cycle the traffic occurs at
+    // Inner vector: Attempted packets at given cycle
+    vector < vector < HardcodedTrafficEntry > > traffic_list;
 };
 
 #endif

--- a/src/GlobalTrafficHardcoding.h
+++ b/src/GlobalTrafficHardcoding.h
@@ -1,0 +1,43 @@
+/*
+ * Noxim - the NoC Simulator
+ *
+ * (C) 2005-2018 by the University of Catania
+ * For the complete list of authors refer to file ../doc/AUTHORS.txt
+ * For the license applied to these sources refer to file ../doc/LICENSE.txt
+ *
+ * This file contains the definition of the global traffic hardcoding
+ */
+
+#ifndef __NOXIMGLOBALTRAFFIC_HARDCODING_H__
+#define __NOXIMGLOBALTRAFFIC_HARDCODING_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include "DataStructs.h"
+
+using namespace std;
+
+// Structure used to store information into the table
+struct HardcodedTrafficEntry {
+  int src;			// ID of the source node (PE)
+  int dst;			// ID of the destination node (PE)
+};
+
+class GlobalTrafficHardcoding {
+
+  public:
+
+    GlobalTrafficHardcoding();
+
+    // Load traffic table from file. Returns true if ok, false otherwise
+    bool load(const char *fname);
+
+  private:
+
+  // Outer vector: Which cycle the traffic occurs at
+  // Inner vector: Attempted packets at given cycle
+  vector < vector < HardcodedTrafficEntry > > traffic_list;
+};
+
+#endif

--- a/src/GlobalTrafficHardcoding.h
+++ b/src/GlobalTrafficHardcoding.h
@@ -38,6 +38,12 @@ class GlobalTrafficHardcoding {
   // Outer vector: Which cycle the traffic occurs at
   // Inner vector: Attempted packets at given cycle
   vector < vector < HardcodedTrafficEntry > > traffic_list;
+
+  public:
+
+  vector < HardcodedTrafficEntry > const& traffic_at_cycle(int cycle) const;
+
+  size_t num_cycles() const;
 };
 
 #endif

--- a/src/NoC.cpp
+++ b/src/NoC.cpp
@@ -118,7 +118,11 @@ void NoC::buildCommon()
 
 	// Check for traffic table availability
 	if (GlobalParams::traffic_distribution == TRAFFIC_TABLE_BASED)
-		assert(gttable.load(GlobalParams::traffic_table_filename.c_str()));
+		assert(ghtable.load(GlobalParams::traffic_table_filename.c_str()));
+
+	// Check for traffic hardcoded availability	
+	if (GlobalParams::traffic_distribution == TRAFFIC_HARDCODED)
+		assert(gttable.load(GlobalParams::traffic_hardcoded_filename.c_str()));
 
 	// Var to track Hub connected ports
 	hub_connected_ports = (int *) calloc(GlobalParams::hub_configuration.size(), sizeof(int));
@@ -204,6 +208,7 @@ void NoC::buildButterfly()
 			// Tell to the PE its coordinates
 			t[i][j]->pe->local_id = tile_id;
 			t[i][j]->pe->traffic_table = &gttable;	// Needed to choose destination
+			t[i][j]->pe->traffic_hardcoded = &ghtable;
 			t[i][j]->pe->never_transmit = true;
 
 			// Map clock and reset
@@ -853,6 +858,7 @@ void NoC::buildBaseline()
 	    // Tell to the PE its coordinates
 	    t[i][j]->pe->local_id = tile_id;
 	    t[i][j]->pe->traffic_table = &gttable;	// Needed to choose destination
+	    t[i][j]->pe->traffic_hardcoded = &ghtable;
 	    t[i][j]->pe->never_transmit = true;
 
 	    // Map clock and reset
@@ -1585,6 +1591,7 @@ void NoC::buildOmega()
 			// Tell to the PE its coordinates
 			t[i][j]->pe->local_id = tile_id;
 			t[i][j]->pe->traffic_table = &gttable;	// Needed to choose destination
+			t[i][j]->pe->traffic_hardcoded = &ghtable;	// Needed to choose destination
 			t[i][j]->pe->never_transmit = true;
 
 			// Map clock and reset

--- a/src/NoC.cpp
+++ b/src/NoC.cpp
@@ -118,11 +118,11 @@ void NoC::buildCommon()
 
 	// Check for traffic table availability
 	if (GlobalParams::traffic_distribution == TRAFFIC_TABLE_BASED)
-		assert(ghtable.load(GlobalParams::traffic_table_filename.c_str()));
+		assert(gttable.load(GlobalParams::traffic_table_filename.c_str()));
 
 	// Check for traffic hardcoded availability	
 	if (GlobalParams::traffic_distribution == TRAFFIC_HARDCODED)
-		assert(gttable.load(GlobalParams::traffic_hardcoded_filename.c_str()));
+		assert(ghtable.load(GlobalParams::traffic_hardcoded_filename.c_str()));
 
 	// Var to track Hub connected ports
 	hub_connected_ports = (int *) calloc(GlobalParams::hub_configuration.size(), sizeof(int));
@@ -543,6 +543,9 @@ void NoC::buildButterfly()
 		}
 		else
 			core[i]->pe->never_transmit = false;
+		
+		if (GlobalParams::traffic_distribution == TRAFFIC_HARDCODED)
+		  core[i]->pe->traffic_hardcoded = &ghtable;
 
 		// Map clock and reset
 		core[i]->clock(clock);
@@ -1307,6 +1310,9 @@ void NoC::buildBaseline()
 	}
 	else
 	    core[i]->pe->never_transmit = false;
+		
+	if (GlobalParams::traffic_distribution == TRAFFIC_HARDCODED)
+	  core[i]->pe->traffic_hardcoded = &ghtable;
 
 	// Map clock and reset
 	core[i]->clock(clock);
@@ -1938,6 +1944,9 @@ void NoC::buildOmega()
 		}
 		else
 			core[i]->pe->never_transmit = false;
+		
+		if (GlobalParams::traffic_distribution == TRAFFIC_HARDCODED)
+		  core[i]->pe->traffic_hardcoded = &ghtable;
 
 		// Map clock and reset
 		core[i]->clock(clock);
@@ -2216,6 +2225,9 @@ void NoC::buildMesh()
 		}
 		else
 			t[i][j]->pe->never_transmit = false;
+		
+		if (GlobalParams::traffic_distribution == TRAFFIC_HARDCODED)
+		  t[i][j]->pe->traffic_hardcoded = &ghtable;
 
 	    // Map clock and reset
 	    t[i][j]->clock(clock);

--- a/src/NoC.h
+++ b/src/NoC.h
@@ -15,6 +15,7 @@
 #include "Tile.h"
 #include "GlobalRoutingTable.h"
 #include "GlobalTrafficTable.h"
+#include "GlobalTrafficHardcoding.h"
 #include "Hub.h"
 #include "Channel.h"
 #include "TokenRing.h"
@@ -86,6 +87,7 @@ SC_MODULE(NoC)
     // Global tables
     GlobalRoutingTable grtable;
     GlobalTrafficTable gttable;
+    GlobalTrafficHardcoding ghtable;
 
 
     // Constructor

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -37,13 +37,20 @@ void ProcessingElement::txProcess()
 	current_level_tx = 0;
 	transmittedAtPreviousCycle = false;
     } else {
-	Packet packet;
 
-	if (canShot(packet)) {
-	    packet_queue.push(packet);
-	    transmittedAtPreviousCycle = true;
-	} else
-	    transmittedAtPreviousCycle = false;
+      if(GlobalParams::traffic_distribution != TRAFFIC_HARDCODED) {
+		Packet packet;
+		if (canShot(packet)) {
+		  packet_queue.push(packet);
+		  transmittedAtPreviousCycle = true;
+		} else {
+		  transmittedAtPreviousCycle = false;
+		}
+      } else {
+		std::cout << "[txProcess] check for ID " << local_id << " at cycle " << traffic_cycle << std::endl;
+		
+		traffic_cycle += 1;
+      }
 
 
 	if (ack_tx.read() == current_level_tx) {

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -46,8 +46,26 @@ void ProcessingElement::txProcess()
 		} else {
 		  transmittedAtPreviousCycle = false;
 		}
-      } else {
-		std::cout << "[txProcess] check for ID " << local_id << " at cycle " << traffic_cycle << std::endl;
+      } else if(traffic_cycle < traffic_hardcoded->num_cycles()) {
+		double now = sc_time_stamp().to_double() / GlobalParams::clock_period_ps;
+		
+		bool any = false;
+		for (HardcodedTrafficEntry const& expected_packet
+			   : traffic_hardcoded->traffic_at_cycle(traffic_cycle)) {
+		  if(expected_packet.src == local_id) {
+			std::cout << "[txProcess] Firing spike " << expected_packet.src << "->" << expected_packet.dst << " at cycle " << traffic_cycle << "/" << traffic_hardcoded->num_cycles() << std::endl;
+			Packet packet;
+			int vc = randInt(0,GlobalParams::n_virtual_channels-1);
+		    packet.make(local_id, expected_packet.dst, vc, now, getRandomSize());
+			packet_queue.push(packet);
+			any = true;
+		  }
+		}
+
+		if(any)
+		  transmittedAtPreviousCycle = true;
+		else
+		  transmittedAtPreviousCycle = false;
 		
 		traffic_cycle += 1;
       }

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -53,7 +53,6 @@ void ProcessingElement::txProcess()
 		for (HardcodedTrafficEntry const& expected_packet
 			   : traffic_hardcoded->traffic_at_cycle(traffic_cycle)) {
 		  if(expected_packet.src == local_id) {
-			std::cout << "[txProcess] Firing spike " << expected_packet.src << "->" << expected_packet.dst << " at cycle " << traffic_cycle << "/" << traffic_hardcoded->num_cycles() << std::endl;
 			Packet packet;
 			int vc = randInt(0,GlobalParams::n_virtual_channels-1);
 		    packet.make(local_id, expected_packet.dst, vc, now, getRandomSize());

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -38,36 +38,36 @@ void ProcessingElement::txProcess()
 	transmittedAtPreviousCycle = false;
     } else {
 
-      if(GlobalParams::traffic_distribution != TRAFFIC_HARDCODED) {
+    if(GlobalParams::traffic_distribution != TRAFFIC_HARDCODED) {
 		Packet packet;
 		if (canShot(packet)) {
-		  packet_queue.push(packet);
-		  transmittedAtPreviousCycle = true;
+			packet_queue.push(packet);
+			transmittedAtPreviousCycle = true;
 		} else {
-		  transmittedAtPreviousCycle = false;
+			transmittedAtPreviousCycle = false;
 		}
-      } else if(traffic_cycle < traffic_hardcoded->num_cycles()) {
+    } else if(traffic_cycle < traffic_hardcoded->num_cycles()) {
 		double now = sc_time_stamp().to_double() / GlobalParams::clock_period_ps;
 		
 		bool any = false;
 		for (HardcodedTrafficEntry const& expected_packet
 			   : traffic_hardcoded->traffic_at_cycle(traffic_cycle)) {
-		  if(expected_packet.src == local_id) {
-			Packet packet;
-			int vc = randInt(0,GlobalParams::n_virtual_channels-1);
-		    packet.make(local_id, expected_packet.dst, vc, now, getRandomSize());
-			packet_queue.push(packet);
-			any = true;
-		  }
+			if(expected_packet.src == local_id) {
+		    	Packet packet;
+				int vc = randInt(0,GlobalParams::n_virtual_channels-1);
+				packet.make(local_id, expected_packet.dst, vc, now, getRandomSize());
+				packet_queue.push(packet);
+				any = true;
+			}
 		}
 
 		if(any)
-		  transmittedAtPreviousCycle = true;
+			transmittedAtPreviousCycle = true;
 		else
-		  transmittedAtPreviousCycle = false;
+			transmittedAtPreviousCycle = false;
 		
 		traffic_cycle += 1;
-      }
+    }
 
 
 	if (ack_tx.read() == current_level_tx) {

--- a/src/ProcessingElement.h
+++ b/src/ProcessingElement.h
@@ -16,6 +16,7 @@
 
 #include "DataStructs.h"
 #include "GlobalTrafficTable.h"
+#include "GlobalTrafficHardcoding.h"
 #include "Utils.h"
 
 using namespace std;
@@ -61,7 +62,9 @@ SC_MODULE(ProcessingElement)
     Packet trafficLocal();	// Random with locality
     Packet trafficULocal();	// Random with locality
 
+    size_t traffic_cycle = 0;
     GlobalTrafficTable *traffic_table;	// Reference to the Global traffic Table
+    GlobalTrafficHardcoding *traffic_hardcoded;	// Reference to the Global traffic Hardcoding
     bool never_transmit;	// true if the PE does not transmit any packet 
     //  (valid only for the table based traffic)
 

--- a/src/tags
+++ b/src/tags
@@ -3,51 +3,51 @@
 !_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
 !_TAG_PROGRAM_NAME	Exuberant Ctags	//
 !_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
-!_TAG_PROGRAM_VERSION	5.8	//
-ANTENNA_BUFFER_FRONT_PWR_D	DataStructs.h	/^    ANTENNA_BUFFER_FRONT_PWR_D,$/;"	e	enum:__anon8
-ANTENNA_BUFFER_POP_PWR_D	DataStructs.h	/^    ANTENNA_BUFFER_POP_PWR_D,$/;"	e	enum:__anon8
-ANTENNA_BUFFER_PUSH_PWR_D	DataStructs.h	/^    ANTENNA_BUFFER_PUSH_PWR_D,$/;"	e	enum:__anon8
-ANTENNA_BUFFER_PWR_S	DataStructs.h	/^    ANTENNA_BUFFER_PWR_S,$/;"	e	enum:__anon9
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+ANTENNA_BUFFER_FRONT_PWR_D	DataStructs.h	/^    ANTENNA_BUFFER_FRONT_PWR_D,$/;"	e	enum:__anon2
+ANTENNA_BUFFER_POP_PWR_D	DataStructs.h	/^    ANTENNA_BUFFER_POP_PWR_D,$/;"	e	enum:__anon2
+ANTENNA_BUFFER_PUSH_PWR_D	DataStructs.h	/^    ANTENNA_BUFFER_PUSH_PWR_D,$/;"	e	enum:__anon2
+ANTENNA_BUFFER_PWR_S	DataStructs.h	/^    ANTENNA_BUFFER_PWR_S,$/;"	e	enum:__anon3
 AdmissibleOutputs	GlobalRoutingTable.h	/^typedef set < LinkId > AdmissibleOutputs;$/;"	t
-BUFFER_FROM_TILE_FRONT_PWR_D	DataStructs.h	/^    BUFFER_FROM_TILE_FRONT_PWR_D,$/;"	e	enum:__anon8
-BUFFER_FROM_TILE_POP_PWR_D	DataStructs.h	/^    BUFFER_FROM_TILE_POP_PWR_D,$/;"	e	enum:__anon8
-BUFFER_FROM_TILE_PUSH_PWR_D	DataStructs.h	/^    BUFFER_FROM_TILE_PUSH_PWR_D,$/;"	e	enum:__anon8
-BUFFER_FROM_TILE_PWR_S	DataStructs.h	/^    BUFFER_FROM_TILE_PWR_S,$/;"	e	enum:__anon9
-BUFFER_FRONT_PWR_D	DataStructs.h	/^    BUFFER_FRONT_PWR_D,$/;"	e	enum:__anon8
-BUFFER_POP_PWR_D	DataStructs.h	/^    BUFFER_POP_PWR_D,$/;"	e	enum:__anon8
-BUFFER_PUSH_PWR_D	DataStructs.h	/^    BUFFER_PUSH_PWR_D,$/;"	e	enum:__anon8
-BUFFER_ROUTER_PWR_S	DataStructs.h	/^    BUFFER_ROUTER_PWR_S,$/;"	e	enum:__anon9
-BUFFER_TO_TILE_FRONT_PWR_D	DataStructs.h	/^    BUFFER_TO_TILE_FRONT_PWR_D,$/;"	e	enum:__anon8
-BUFFER_TO_TILE_POP_PWR_D	DataStructs.h	/^    BUFFER_TO_TILE_POP_PWR_D,$/;"	e	enum:__anon8
-BUFFER_TO_TILE_PUSH_PWR_D	DataStructs.h	/^    BUFFER_TO_TILE_PUSH_PWR_D,$/;"	e	enum:__anon8
-BUFFER_TO_TILE_PWR_S	DataStructs.h	/^    BUFFER_TO_TILE_PWR_S,$/;"	e	enum:__anon9
+BUFFER_FROM_TILE_FRONT_PWR_D	DataStructs.h	/^    BUFFER_FROM_TILE_FRONT_PWR_D,$/;"	e	enum:__anon2
+BUFFER_FROM_TILE_POP_PWR_D	DataStructs.h	/^    BUFFER_FROM_TILE_POP_PWR_D,$/;"	e	enum:__anon2
+BUFFER_FROM_TILE_PUSH_PWR_D	DataStructs.h	/^    BUFFER_FROM_TILE_PUSH_PWR_D,$/;"	e	enum:__anon2
+BUFFER_FROM_TILE_PWR_S	DataStructs.h	/^    BUFFER_FROM_TILE_PWR_S,$/;"	e	enum:__anon3
+BUFFER_FRONT_PWR_D	DataStructs.h	/^    BUFFER_FRONT_PWR_D,$/;"	e	enum:__anon2
+BUFFER_POP_PWR_D	DataStructs.h	/^    BUFFER_POP_PWR_D,$/;"	e	enum:__anon2
+BUFFER_PUSH_PWR_D	DataStructs.h	/^    BUFFER_PUSH_PWR_D,$/;"	e	enum:__anon2
+BUFFER_ROUTER_PWR_S	DataStructs.h	/^    BUFFER_ROUTER_PWR_S,$/;"	e	enum:__anon3
+BUFFER_TO_TILE_FRONT_PWR_D	DataStructs.h	/^    BUFFER_TO_TILE_FRONT_PWR_D,$/;"	e	enum:__anon2
+BUFFER_TO_TILE_POP_PWR_D	DataStructs.h	/^    BUFFER_TO_TILE_POP_PWR_D,$/;"	e	enum:__anon2
+BUFFER_TO_TILE_PUSH_PWR_D	DataStructs.h	/^    BUFFER_TO_TILE_PUSH_PWR_D,$/;"	e	enum:__anon2
+BUFFER_TO_TILE_PWR_S	DataStructs.h	/^    BUFFER_TO_TILE_PWR_S,$/;"	e	enum:__anon3
 Buffer	Buffer.cpp	/^Buffer::Buffer()$/;"	f	class:Buffer
 Buffer	Buffer.h	/^class Buffer {$/;"	c
 BufferBank	Buffer.h	/^typedef Buffer BufferBank[MAX_VIRTUAL_CHANNELS];$/;"	t
-BufferPowerConfig	GlobalParams.h	/^} BufferPowerConfig;$/;"	t	typeref:struct:__anon3
-COLUMN_AOC	GlobalRoutingTable.h	/^#define COLUMN_AOC /;"	d
-CONFIG_FILENAME	GlobalParams.h	/^#define CONFIG_FILENAME /;"	d
-CROSSBAR_PWR_D	DataStructs.h	/^    CROSSBAR_PWR_D,$/;"	e	enum:__anon8
-CROSSBAR_PWR_S	DataStructs.h	/^    CROSSBAR_PWR_S,$/;"	e	enum:__anon9
-CXX	Makefile	/^CXX      := g++$/;"	m
-CXXFLAGS	Makefile	/^CXXFLAGS := $(OPT) $(OTHER) $(DEBUG)$/;"	m
+BufferPowerConfig	GlobalParams.h	/^} BufferPowerConfig;$/;"	t	typeref:struct:__anon7
+CHSEL_FIRST_FREE	GlobalParams.h	64;"	d
+CHSEL_RANDOM	GlobalParams.h	63;"	d
+COLUMN_AOC	GlobalRoutingTable.h	13;"	d
+CONFIG_FILENAME	GlobalParams.h	22;"	d
+CROSSBAR_PWR_D	DataStructs.h	/^    CROSSBAR_PWR_D,$/;"	e	enum:__anon2
+CROSSBAR_PWR_S	DataStructs.h	/^    CROSSBAR_PWR_S,$/;"	e	enum:__anon3
 Channel	Channel.h	/^  Channel(sc_module_name nm, int id)$/;"	f	struct:Channel
 Channel	Channel.h	/^struct Channel: sc_module$/;"	s
-ChannelConfig	GlobalParams.h	/^} ChannelConfig;$/;"	t	typeref:struct:__anon1
+ChannelConfig	GlobalParams.h	/^} ChannelConfig;$/;"	t	typeref:struct:__anon5
 ChannelStatus	DataStructs.h	/^struct ChannelStatus {$/;"	s
 CommHistory	Stats.h	/^struct CommHistory {$/;"	s
 Communication	GlobalTrafficTable.h	/^struct Communication {$/;"	s
 Coord	DataStructs.h	/^class Coord {$/;"	c
-DEBUG	Makefile	/^DEBUG    := #-g -DDEBUG$/;"	m
-DEFAULT_VC	GlobalParams.h	/^#define DEFAULT_VC /;"	d
-DIRECTIONS	GlobalParams.h	/^#define DIRECTIONS /;"	d
-DIRECTION_EAST	GlobalParams.h	/^#define DIRECTION_EAST /;"	d
-DIRECTION_HUB	GlobalParams.h	/^#define DIRECTION_HUB /;"	d
-DIRECTION_LOCAL	GlobalParams.h	/^#define DIRECTION_LOCAL /;"	d
-DIRECTION_NORTH	GlobalParams.h	/^#define DIRECTION_NORTH /;"	d
-DIRECTION_SOUTH	GlobalParams.h	/^#define DIRECTION_SOUTH /;"	d
-DIRECTION_WEST	GlobalParams.h	/^#define DIRECTION_WEST /;"	d
-DIRECTION_WIRELESS	GlobalParams.h	/^#define DIRECTION_WIRELESS /;"	d
+DEFAULT_VC	GlobalParams.h	37;"	d
+DIRECTIONS	GlobalParams.h	26;"	d
+DIRECTION_EAST	GlobalParams.h	28;"	d
+DIRECTION_HUB	GlobalParams.h	32;"	d
+DIRECTION_HUB_RELAY	GlobalParams.h	33;"	d
+DIRECTION_LOCAL	GlobalParams.h	31;"	d
+DIRECTION_NORTH	GlobalParams.h	27;"	d
+DIRECTION_SOUTH	GlobalParams.h	29;"	d
+DIRECTION_WEST	GlobalParams.h	30;"	d
+DIRECTION_WIRELESS	GlobalParams.h	34;"	d
 Disable	Buffer.cpp	/^void Buffer::Disable()$/;"	f	class:Buffer
 Drop	Buffer.cpp	/^void Buffer::Drop(const Flit & flit) const$/;"	f	class:Buffer
 Empty	Buffer.cpp	/^void Buffer::Empty() const$/;"	f	class:Buffer
@@ -63,44 +63,39 @@ GlobalRoutingTable	GlobalRoutingTable.cpp	/^GlobalRoutingTable::GlobalRoutingTab
 GlobalRoutingTable	GlobalRoutingTable.h	/^class GlobalRoutingTable {$/;"	c
 GlobalStats	GlobalStats.cpp	/^GlobalStats::GlobalStats(const NoC * _noc)$/;"	f	class:GlobalStats
 GlobalStats	GlobalStats.h	/^class GlobalStats {$/;"	c
+GlobalTrafficHardcoding	GlobalTrafficHardcoding.cpp	/^GlobalTrafficHardcoding::GlobalTrafficHardcoding()$/;"	f	class:GlobalTrafficHardcoding
+GlobalTrafficHardcoding	GlobalTrafficHardcoding.h	/^class GlobalTrafficHardcoding {$/;"	c
 GlobalTrafficTable	GlobalTrafficTable.cpp	/^GlobalTrafficTable::GlobalTrafficTable()$/;"	f	class:GlobalTrafficTable
 GlobalTrafficTable	GlobalTrafficTable.h	/^class GlobalTrafficTable {$/;"	c
-HOLD_CHANNEL	GlobalParams.h	/^#define HOLD_CHANNEL /;"	d
-HubConfig	GlobalParams.h	/^} HubConfig;$/;"	t	typeref:struct:__anon2
-HubPowerConfig	GlobalParams.h	/^} HubPowerConfig;$/;"	t	typeref:struct:__anon5
-INCDIR	Makefile	/^INCDIR := -I$(SRCDIR) -isystem $(SYSTEMC)\/include -I$(YAML)\/include$/;"	m
+HOLD_CHANNEL	GlobalParams.h	88;"	d
+HardcodedTrafficEntry	GlobalTrafficHardcoding.h	/^struct HardcodedTrafficEntry {$/;"	s
+HubConfig	GlobalParams.h	/^} HubConfig;$/;"	t	typeref:struct:__anon6
+HubPowerConfig	GlobalParams.h	/^} HubPowerConfig;$/;"	t	typeref:struct:__anon9
 Initiator	Initiator.h	/^  Initiator(sc_module_name nm,Hub* h): sc_module(nm),hub(h), socket("socket")$/;"	f	struct:Initiator
 Initiator	Initiator.h	/^struct Initiator: sc_module$/;"	s
 IsEmpty	Buffer.cpp	/^bool Buffer::IsEmpty() const$/;"	f	class:Buffer
 IsFull	Buffer.cpp	/^bool Buffer::IsFull() const$/;"	f	class:Buffer
-LIBDIR	Makefile	/^LIBDIR := -L$(SRCDIR) -L$(SYSTEMC_LIBS) -L$(YAML)\/lib$/;"	m
-LIBS	Makefile	/^LIBS := -lsystemc -lm -lyaml-cpp $/;"	m
-LINK_R2H_PWR_D	DataStructs.h	/^    LINK_R2H_PWR_D,$/;"	e	enum:__anon8
-LINK_R2H_PWR_S	DataStructs.h	/^    LINK_R2H_PWR_S,$/;"	e	enum:__anon9
-LINK_R2R_PWR_D	DataStructs.h	/^    LINK_R2R_PWR_D,$/;"	e	enum:__anon8
-LOG	Utils.h	/^#define LOG /;"	d
+LINK_R2H_PWR_D	DataStructs.h	/^    LINK_R2H_PWR_D,$/;"	e	enum:__anon2
+LINK_R2H_PWR_S	DataStructs.h	/^    LINK_R2H_PWR_S,$/;"	e	enum:__anon3
+LINK_R2R_PWR_D	DataStructs.h	/^    LINK_R2R_PWR_D,$/;"	e	enum:__anon2
 LOG	Utils.h	/^static onullstream LOG;$/;"	v
+LOG	Utils.h	23;"	d
 LinkBitLinePowerConfig	GlobalParams.h	/^typedef map<double, pair <double, double> > LinkBitLinePowerConfig;$/;"	t
 LinkId	GlobalRoutingTable.h	/^typedef pair < int, int >LinkId;$/;"	t
 LocalRoutingTable	LocalRoutingTable.cpp	/^LocalRoutingTable::LocalRoutingTable()$/;"	f	class:LocalRoutingTable
 LocalRoutingTable	LocalRoutingTable.h	/^class LocalRoutingTable {$/;"	c
-MAX_VIRTUAL_CHANNELS	GlobalParams.h	/^#define MAX_VIRTUAL_CHANNELS	/;"	d
-MEM_SIZE	Target.h	/^#define MEM_SIZE /;"	d
-MODULE	Makefile	/^MODULE := noxim$/;"	m
-NI_PWR_D	DataStructs.h	/^    NI_PWR_D,$/;"	e	enum:__anon8
-NI_PWR_S	DataStructs.h	/^    NI_PWR_S,$/;"	e	enum:__anon9
-NOT_RESERVED	GlobalParams.h	/^#define NOT_RESERVED /;"	d
-NOT_VALID	GlobalParams.h	/^#define NOT_VALID /;"	d
-NO_BREAKDOWN_ENTRIES_D	DataStructs.h	/^    NO_BREAKDOWN_ENTRIES_D$/;"	e	enum:__anon8
-NO_BREAKDOWN_ENTRIES_S	DataStructs.h	/^    NO_BREAKDOWN_ENTRIES_S$/;"	e	enum:__anon9
+MAX_VIRTUAL_CHANNELS	GlobalParams.h	36;"	d
+MEM_SIZE	Target.h	24;"	d
+NI_PWR_D	DataStructs.h	/^    NI_PWR_D,$/;"	e	enum:__anon2
+NI_PWR_S	DataStructs.h	/^    NI_PWR_S,$/;"	e	enum:__anon3
+NOT_RESERVED	GlobalParams.h	45;"	d
+NOT_VALID	GlobalParams.h	48;"	d
+NO_BREAKDOWN_ENTRIES_D	DataStructs.h	/^    NO_BREAKDOWN_ENTRIES_D$/;"	e	enum:__anon2
+NO_BREAKDOWN_ENTRIES_S	DataStructs.h	/^    NO_BREAKDOWN_ENTRIES_S$/;"	e	enum:__anon3
 NoPScore	Router.cpp	/^int Router::NoPScore(const NoP_data & nop_data,$/;"	f	class:Router
 NoP_data	DataStructs.h	/^struct NoP_data {$/;"	s
 NoP_report	Router.cpp	/^void Router::NoP_report() const$/;"	f	class:Router
-OBJDIR	Makefile	/^OBJDIR  := .\/build$/;"	m
-OBJS	Makefile	/^OBJS := $(subst $(SRCDIR),$(OBJDIR),$(SRCS:.cpp=.o))$/;"	m
-OPT	Makefile	/^OPT      := -O3$/;"	m
-OTHER	Makefile	/^OTHER    := -Wall -DSC_NO_WRITE_CHECK# -Wno-deprecated$/;"	m
-POWER_CONFIG_FILENAME	GlobalParams.h	/^#define POWER_CONFIG_FILENAME /;"	d
+POWER_CONFIG_FILENAME	GlobalParams.h	23;"	d
 Packet	DataStructs.h	/^    Packet() { }$/;"	f	struct:Packet
 Packet	DataStructs.h	/^    Packet(const int s, const int d, const int vc, const double ts, const int sz) {$/;"	f	struct:Packet
 Packet	DataStructs.h	/^struct Packet {$/;"	s
@@ -108,72 +103,38 @@ Payload	DataStructs.h	/^struct Payload {$/;"	s
 Pop	Buffer.cpp	/^Flit Buffer::Pop()$/;"	f	class:Buffer
 Power	Power.cpp	/^Power::Power()$/;"	f	class:Power
 Power	Power.h	/^class Power {$/;"	c
-PowerBreakdown	DataStructs.h	/^} PowerBreakdown;$/;"	t	typeref:struct:__anon10
-PowerBreakdownEntry	DataStructs.h	/^} PowerBreakdownEntry;$/;"	t	typeref:struct:__anon7
-PowerConfig	GlobalParams.h	/^} PowerConfig;$/;"	t	typeref:struct:__anon6
+PowerBreakdown	DataStructs.h	/^} PowerBreakdown;$/;"	t	typeref:struct:__anon4
+PowerBreakdownEntry	DataStructs.h	/^} PowerBreakdownEntry;$/;"	t	typeref:struct:__anon1
+PowerConfig	GlobalParams.h	/^} PowerConfig;$/;"	t	typeref:struct:__anon10
 Print	Buffer.cpp	/^void Buffer::Print()$/;"	f	class:Buffer
 Push	Buffer.cpp	/^void Buffer::Push(const Flit & flit)$/;"	f	class:Buffer
-RELEASE_CHANNEL	GlobalParams.h	/^#define RELEASE_CHANNEL /;"	d
-ROUTING_DYAD	GlobalParams.h	/^#define ROUTING_DYAD /;"	d
-ROUTING_PWR_D	DataStructs.h	/^    ROUTING_PWR_D,$/;"	e	enum:__anon8
-ROUTING_PWR_S	DataStructs.h	/^    ROUTING_PWR_S,$/;"	e	enum:__anon9
-ROUTING_TABLE_BASED	GlobalParams.h	/^#define ROUTING_TABLE_BASED /;"	d
+RELEASE_CHANNEL	GlobalParams.h	87;"	d
+ROUTING_DYAD	GlobalParams.h	58;"	d
+ROUTING_PWR_D	DataStructs.h	/^    ROUTING_PWR_D,$/;"	e	enum:__anon2
+ROUTING_PWR_S	DataStructs.h	/^    ROUTING_PWR_S,$/;"	e	enum:__anon3
+ROUTING_TABLE_BASED	GlobalParams.h	59;"	d
 RTEntry	ReservationTable.h	/^typedef struct RTEntry$/;"	s
-RT_ALREADY	GlobalParams.h	/^#define RT_ALREADY /;"	d
-RT_AVAILABLE	GlobalParams.h	/^#define RT_AVAILABLE /;"	d
-RT_OUTVC_BUSY	GlobalParams.h	/^#define RT_OUTVC_BUSY /;"	d
+RT_ALREADY_OTHER_OUT	GlobalParams.h	41;"	d
+RT_ALREADY_SAME	GlobalParams.h	40;"	d
+RT_AVAILABLE	GlobalParams.h	39;"	d
+RT_OUTVC_BUSY	GlobalParams.h	42;"	d
 ReservationTable	ReservationTable.cpp	/^ReservationTable::ReservationTable()$/;"	f	class:ReservationTable
 ReservationTable	ReservationTable.h	/^class ReservationTable {$/;"	c
 RouteData	DataStructs.h	/^struct RouteData {$/;"	s
-RouterPowerConfig	GlobalParams.h	/^} RouterPowerConfig;$/;"	t	typeref:struct:__anon4
-RoutingAlgorithm	routingAlgorithms/RoutingAlgorithm.h	/^class RoutingAlgorithm$/;"	c
-RoutingAlgorithms	routingAlgorithms/RoutingAlgorithms.h	/^class RoutingAlgorithms {$/;"	c
-RoutingAlgorithmsMap	routingAlgorithms/RoutingAlgorithms.h	/^typedef map<string, RoutingAlgorithm * > RoutingAlgorithmsMap;$/;"	t
-RoutingAlgorithmsRegister	routingAlgorithms/RoutingAlgorithms.h	/^	RoutingAlgorithmsRegister(const string & routingAlgorithmName, RoutingAlgorithm * routingAlgorithm) {$/;"	f	struct:RoutingAlgorithmsRegister
-RoutingAlgorithmsRegister	routingAlgorithms/RoutingAlgorithms.h	/^struct RoutingAlgorithmsRegister : RoutingAlgorithms {$/;"	s
+RouterPowerConfig	GlobalParams.h	/^} RouterPowerConfig;$/;"	t	typeref:struct:__anon8
 RoutingTableLink	GlobalRoutingTable.h	/^typedef map < int, AdmissibleOutputs > RoutingTableLink;$/;"	t
 RoutingTableNoC	GlobalRoutingTable.h	/^typedef map < int, RoutingTableNode > RoutingTableNoC;$/;"	t
 RoutingTableNode	GlobalRoutingTable.h	/^typedef map < LinkId, RoutingTableLink > RoutingTableNode;$/;"	t
-Routing_DYAD	routingAlgorithms/Routing_DYAD.h	/^		Routing_DYAD(){};$/;"	f	class:Routing_DYAD
-Routing_DYAD	routingAlgorithms/Routing_DYAD.h	/^class Routing_DYAD : RoutingAlgorithm {$/;"	c
-Routing_NEGATIVE_FIRST	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^		Routing_NEGATIVE_FIRST(){};$/;"	f	class:Routing_NEGATIVE_FIRST
-Routing_NEGATIVE_FIRST	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^class Routing_NEGATIVE_FIRST : RoutingAlgorithm {$/;"	c
-Routing_NORTH_LAST	routingAlgorithms/Routing_NORTH_LAST.h	/^		Routing_NORTH_LAST(){};$/;"	f	class:Routing_NORTH_LAST
-Routing_NORTH_LAST	routingAlgorithms/Routing_NORTH_LAST.h	/^class Routing_NORTH_LAST : RoutingAlgorithm {$/;"	c
-Routing_ODD_EVEN	routingAlgorithms/Routing_ODD_EVEN.h	/^		Routing_ODD_EVEN(){};$/;"	f	class:Routing_ODD_EVEN
-Routing_ODD_EVEN	routingAlgorithms/Routing_ODD_EVEN.h	/^class Routing_ODD_EVEN : RoutingAlgorithm {$/;"	c
-Routing_TABLE_BASED	routingAlgorithms/Routing_TABLE_BASED.h	/^		Routing_TABLE_BASED(){};$/;"	f	class:Routing_TABLE_BASED
-Routing_TABLE_BASED	routingAlgorithms/Routing_TABLE_BASED.h	/^class Routing_TABLE_BASED : RoutingAlgorithm {$/;"	c
-Routing_WEST_FIRST	routingAlgorithms/Routing_WEST_FIRST.h	/^		Routing_WEST_FIRST(){};$/;"	f	class:Routing_WEST_FIRST
-Routing_WEST_FIRST	routingAlgorithms/Routing_WEST_FIRST.h	/^class Routing_WEST_FIRST : RoutingAlgorithm {$/;"	c
-Routing_XY	routingAlgorithms/Routing_XY.h	/^		Routing_XY(){};$/;"	f	class:Routing_XY
-Routing_XY	routingAlgorithms/Routing_XY.h	/^class Routing_XY : RoutingAlgorithm {$/;"	c
 SC_MODULE	Hub.h	/^SC_MODULE(Hub)$/;"	f
 SC_MODULE	NoC.h	/^SC_MODULE(NoC)$/;"	f
 SC_MODULE	ProcessingElement.h	/^SC_MODULE(ProcessingElement)$/;"	f
 SC_MODULE	Router.h	/^SC_MODULE(Router)$/;"	f
 SC_MODULE	Tile.h	/^SC_MODULE(Tile)$/;"	f
 SC_MODULE	TokenRing.h	/^SC_MODULE(TokenRing)$/;"	f
-SELECTION_PWR_D	DataStructs.h	/^    SELECTION_PWR_D,$/;"	e	enum:__anon8
-SELECTION_PWR_S	DataStructs.h	/^    SELECTION_PWR_S,$/;"	e	enum:__anon9
-SPACE	Makefile	/^SPACE := $(subst ,, )$/;"	m
-SRCDIR	Makefile	/^SRCDIR  := ..\/src$/;"	m
-SRCS	Makefile	/^SRCS := $(wildcard $(SRCDIR)\/*.cpp) $(wildcard $(addsuffix *.cpp,$(SUBDIRS)))$/;"	m
-SUBDIRS	Makefile	/^SUBDIRS := $(filter %\/,$(wildcard $(SRCDIR)\/*\/))$/;"	m
-SYSTEMC	Makefile	/^SYSTEMC := \/usr\/local\/systemc-2.3.1$/;"	m
-SYSTEMC_LIBS	Makefile	/^SYSTEMC_LIBS := $(wildcard $(SYSTEMC)\/lib-*)$/;"	m
+SELECTION_PWR_D	DataStructs.h	/^    SELECTION_PWR_D,$/;"	e	enum:__anon2
+SELECTION_PWR_S	DataStructs.h	/^    SELECTION_PWR_S,$/;"	e	enum:__anon3
+STATIC_MAX_CHANNELS	Hub.h	123;"	d
 SaveOccupancyAndTime	Buffer.cpp	/^void Buffer::SaveOccupancyAndTime()$/;"	f	class:Buffer
-SelectionStrategies	selectionStrategies/SelectionStrategies.h	/^class SelectionStrategies {$/;"	c
-SelectionStrategiesMap	selectionStrategies/SelectionStrategies.h	/^typedef map<string, SelectionStrategy* > SelectionStrategiesMap;$/;"	t
-SelectionStrategiesRegister	selectionStrategies/SelectionStrategies.h	/^	SelectionStrategiesRegister(const string & selectionStrategyName, SelectionStrategy * selectionStrategy) {$/;"	f	struct:SelectionStrategiesRegister
-SelectionStrategiesRegister	selectionStrategies/SelectionStrategies.h	/^struct SelectionStrategiesRegister : SelectionStrategies {$/;"	s
-SelectionStrategy	selectionStrategies/SelectionStrategy.h	/^class SelectionStrategy$/;"	c
-Selection_BUFFER_LEVEL	selectionStrategies/Selection_BUFFER_LEVEL.h	/^		Selection_BUFFER_LEVEL(){};$/;"	f	class:Selection_BUFFER_LEVEL
-Selection_BUFFER_LEVEL	selectionStrategies/Selection_BUFFER_LEVEL.h	/^class Selection_BUFFER_LEVEL : SelectionStrategy {$/;"	c
-Selection_NOP	selectionStrategies/Selection_NOP.h	/^		Selection_NOP(){};$/;"	f	class:Selection_NOP
-Selection_NOP	selectionStrategies/Selection_NOP.h	/^class Selection_NOP : SelectionStrategy {$/;"	c
-Selection_RANDOM	selectionStrategies/Selection_RANDOM.h	/^		Selection_RANDOM(){};$/;"	f	class:Selection_RANDOM
-Selection_RANDOM	selectionStrategies/Selection_RANDOM.h	/^class Selection_RANDOM : SelectionStrategy {$/;"	c
 SetMaxBufferSize	Buffer.cpp	/^void Buffer::SetMaxBufferSize(const unsigned int bms)$/;"	f	class:Buffer
 ShowBuffersStats	Router.cpp	/^void Router::ShowBuffersStats(std::ostream & out)$/;"	f	class:Router
 ShowStats	Buffer.cpp	/^void Buffer::ShowStats(std::ostream & out)$/;"	f	class:Buffer
@@ -182,76 +143,67 @@ Stats	Stats.h	/^    Stats() {$/;"	f	class:Stats
 Stats	Stats.h	/^class Stats {$/;"	c
 TBufferFullStatus	DataStructs.h	/^    TBufferFullStatus()$/;"	f	struct:TBufferFullStatus
 TBufferFullStatus	DataStructs.h	/^struct TBufferFullStatus {$/;"	s
-TOKEN_HOLD	GlobalParams.h	/^#define TOKEN_HOLD /;"	d
-TOKEN_MAX_HOLD	GlobalParams.h	/^#define TOKEN_MAX_HOLD /;"	d
-TOKEN_PACKET	GlobalParams.h	/^#define TOKEN_PACKET /;"	d
-TRAFFIC_BIT_REVERSAL	GlobalParams.h	/^#define TRAFFIC_BIT_REVERSAL /;"	d
-TRAFFIC_BUTTERFLY	GlobalParams.h	/^#define TRAFFIC_BUTTERFLY /;"	d
-TRAFFIC_HOTSPOT	GlobalParams.h	/^#define TRAFFIC_HOTSPOT /;"	d
-TRAFFIC_LOCAL	GlobalParams.h	/^#define TRAFFIC_LOCAL	/;"	d
-TRAFFIC_RANDOM	GlobalParams.h	/^#define TRAFFIC_RANDOM /;"	d
-TRAFFIC_HARDCODED	GlobalParams.h	/^#define TRAFFIC_HARDCODED /;"	d
-TRAFFIC_SHUFFLE	GlobalParams.h	/^#define TRAFFIC_SHUFFLE /;"	d
-TRAFFIC_TABLE_BASED	GlobalParams.h	/^#define TRAFFIC_TABLE_BASED /;"	d
-TRAFFIC_TRANSPOSE1	GlobalParams.h	/^#define TRAFFIC_TRANSPOSE1 /;"	d
-TRAFFIC_TRANSPOSE2	GlobalParams.h	/^#define TRAFFIC_TRANSPOSE2 /;"	d
-TRAFFIC_ULOCAL	GlobalParams.h	/^#define TRAFFIC_ULOCAL	/;"	d
-TRANSCEIVER_RX_PWR_BIASING	DataStructs.h	/^    TRANSCEIVER_RX_PWR_BIASING,$/;"	e	enum:__anon9
-TRANSCEIVER_RX_PWR_S	DataStructs.h	/^    TRANSCEIVER_RX_PWR_S,$/;"	e	enum:__anon9
-TRANSCEIVER_TX_PWR_BIASING	DataStructs.h	/^    TRANSCEIVER_TX_PWR_BIASING,$/;"	e	enum:__anon9
-TRANSCEIVER_TX_PWR_S	DataStructs.h	/^    TRANSCEIVER_TX_PWR_S,$/;"	e	enum:__anon9
+TOKEN_HOLD	GlobalParams.h	90;"	d
+TOKEN_MAX_HOLD	GlobalParams.h	91;"	d
+TOKEN_PACKET	GlobalParams.h	92;"	d
+TOPOLOGY_BASELINE	GlobalParams.h	53;"	d
+TOPOLOGY_BUTTERFLY	GlobalParams.h	54;"	d
+TOPOLOGY_MESH	GlobalParams.h	51;"	d
+TOPOLOGY_OMEGA	GlobalParams.h	55;"	d
+TRAFFIC_BIT_REVERSAL	GlobalParams.h	72;"	d
+TRAFFIC_BUTTERFLY	GlobalParams.h	74;"	d
+TRAFFIC_HARDCODED	GlobalParams.h	77;"	d
+TRAFFIC_HOTSPOT	GlobalParams.h	70;"	d
+TRAFFIC_LOCAL	GlobalParams.h	75;"	d
+TRAFFIC_RANDOM	GlobalParams.h	67;"	d
+TRAFFIC_SHUFFLE	GlobalParams.h	73;"	d
+TRAFFIC_TABLE_BASED	GlobalParams.h	71;"	d
+TRAFFIC_TRANSPOSE1	GlobalParams.h	68;"	d
+TRAFFIC_TRANSPOSE2	GlobalParams.h	69;"	d
+TRAFFIC_ULOCAL	GlobalParams.h	76;"	d
+TRANSCEIVER_RX_PWR_BIASING	DataStructs.h	/^    TRANSCEIVER_RX_PWR_BIASING,$/;"	e	enum:__anon3
+TRANSCEIVER_RX_PWR_S	DataStructs.h	/^    TRANSCEIVER_RX_PWR_S,$/;"	e	enum:__anon3
+TRANSCEIVER_TX_PWR_BIASING	DataStructs.h	/^    TRANSCEIVER_TX_PWR_BIASING,$/;"	e	enum:__anon3
+TRANSCEIVER_TX_PWR_S	DataStructs.h	/^    TRANSCEIVER_TX_PWR_S,$/;"	e	enum:__anon3
 TRTEntry	ReservationTable.h	/^} TRTEntry;$/;"	t	typeref:struct:RTEntry
 TReservation	ReservationTable.h	/^struct TReservation$/;"	s
 Target	Target.h	/^  Target(sc_module_name nm, int id, Hub* h): sc_module(nm), hub(h), socket("socket")$/;"	f	struct:Target
 Target	Target.h	/^struct Target: sc_module$/;"	s
 UpdateMeanOccupancy	Buffer.cpp	/^void Buffer::UpdateMeanOccupancy()$/;"	f	class:Buffer
-VERBOSE_HIGH	GlobalParams.h	/^#define VERBOSE_HIGH /;"	d
-VERBOSE_LOW	GlobalParams.h	/^#define VERBOSE_LOW /;"	d
-VERBOSE_MEDIUM	GlobalParams.h	/^#define VERBOSE_MEDIUM /;"	d
-VERBOSE_OFF	GlobalParams.h	/^#define VERBOSE_OFF /;"	d
-VPATH	Makefile	/^VPATH := $(SRCDIR):$(subst $(SPACE),:,$(SUBDIRS))$/;"	m
-W2J	Power.cpp	/^#define W2J(/;"	d	file:
-WIRELESS_DYNAMIC_RX_PWR	DataStructs.h	/^    WIRELESS_DYNAMIC_RX_PWR,$/;"	e	enum:__anon8
-WIRELESS_SNOOPING	DataStructs.h	/^    WIRELESS_SNOOPING,$/;"	e	enum:__anon8
-WIRELESS_TX	DataStructs.h	/^    WIRELESS_TX,$/;"	e	enum:__anon8
+VERBOSE_HIGH	GlobalParams.h	83;"	d
+VERBOSE_LOW	GlobalParams.h	81;"	d
+VERBOSE_MEDIUM	GlobalParams.h	82;"	d
+VERBOSE_OFF	GlobalParams.h	80;"	d
+W2J	Power.cpp	16;"	d	file:
+WIRELESS_DYNAMIC_RX_PWR	DataStructs.h	/^    WIRELESS_DYNAMIC_RX_PWR,$/;"	e	enum:__anon2
+WIRELESS_SNOOPING	DataStructs.h	/^    WIRELESS_SNOOPING,$/;"	e	enum:__anon2
+WIRELESS_TX	DataStructs.h	/^    WIRELESS_TX,$/;"	e	enum:__anon2
 YAML	ConfigurationManager.h	/^namespace YAML {$/;"	n
-YAML	Makefile	/^YAML    := \/opt\/local$/;"	m
-_DATASTRUCS_H__	DataStructs.h	/^#define _DATASTRUCS_H__$/;"	d
-__BUS_H__	Channel.h	/^#define __BUS_H__$/;"	d
-__MM_H__	MM.h	/^#define __MM_H__$/;"	d
-__NOXIMBUFFER_H__	Buffer.h	/^#define __NOXIMBUFFER_H__$/;"	d
-__NOXIMCONFIGURATIONMANAGER_H__	ConfigurationManager.h	/^#define __NOXIMCONFIGURATIONMANAGER_H__$/;"	d
-__NOXIMGLOBALPARAMS_H__	GlobalParams.h	/^#define __NOXIMGLOBALPARAMS_H__ /;"	d
-__NOXIMGLOBALROUTINGTABLE_H__	GlobalRoutingTable.h	/^#define __NOXIMGLOBALROUTINGTABLE_H__$/;"	d
-__NOXIMGLOBALSTATS_H__	GlobalStats.h	/^#define __NOXIMGLOBALSTATS_H__$/;"	d
-__NOXIMGLOBALTRAFFIC_TABLE_H__	GlobalTrafficTable.h	/^#define __NOXIMGLOBALTRAFFIC_TABLE_H__$/;"	d
-__NOXIMHUB_H__	Hub.h	/^#define __NOXIMHUB_H__$/;"	d
-__NOXIMLOCALROUTINGTABLE_H__	LocalRoutingTable.h	/^#define __NOXIMLOCALROUTINGTABLE_H__$/;"	d
-__NOXIMNOC_H__	NoC.h	/^#define __NOXIMNOC_H__$/;"	d
-__NOXIMPOWER_H__	Power.h	/^#define __NOXIMPOWER_H__$/;"	d
-__NOXIMPROCESSINGELEMENT_H__	ProcessingElement.h	/^#define __NOXIMPROCESSINGELEMENT_H__$/;"	d
-__NOXIMRESERVATIONTABLE_H__	ReservationTable.h	/^#define __NOXIMRESERVATIONTABLE_H__$/;"	d
-__NOXIMROUTER_H__	Router.h	/^#define __NOXIMROUTER_H__$/;"	d
-__NOXIMROUTINGALGORITHMS_H__	routingAlgorithms/RoutingAlgorithms.h	/^#define __NOXIMROUTINGALGORITHMS_H__$/;"	d
-__NOXIMROUTINGALGORITHM_H__	routingAlgorithms/RoutingAlgorithm.h	/^#define __NOXIMROUTINGALGORITHM_H__$/;"	d
-__NOXIMROUTING_DYAD_H__	routingAlgorithms/Routing_DYAD.h	/^#define __NOXIMROUTING_DYAD_H__$/;"	d
-__NOXIMROUTING_NEGATIVE_FIRST_H__	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^#define __NOXIMROUTING_NEGATIVE_FIRST_H__$/;"	d
-__NOXIMROUTING_NORTH_LAST_H__	routingAlgorithms/Routing_NORTH_LAST.h	/^#define __NOXIMROUTING_NORTH_LAST_H__$/;"	d
-__NOXIMROUTING_ODD_EVEN_H__	routingAlgorithms/Routing_ODD_EVEN.h	/^#define __NOXIMROUTING_ODD_EVEN_H__$/;"	d
-__NOXIMROUTING_TABLE_BASED_H__	routingAlgorithms/Routing_TABLE_BASED.h	/^#define __NOXIMROUTING_TABLE_BASED_H__$/;"	d
-__NOXIMROUTING_WEST_FIRST_H__	routingAlgorithms/Routing_WEST_FIRST.h	/^#define __NOXIMROUTING_WEST_FIRST_H__$/;"	d
-__NOXIMROUTING_XY_H__	routingAlgorithms/Routing_XY.h	/^#define __NOXIMROUTING_XY_H__$/;"	d
-__NOXIMSELECTIONSTRATEGIES_H__	selectionStrategies/SelectionStrategies.h	/^#define __NOXIMSELECTIONSTRATEGIES_H__$/;"	d
-__NOXIMSELECTIONSTRATEGY_H__	selectionStrategies/SelectionStrategy.h	/^#define __NOXIMSELECTIONSTRATEGY_H__$/;"	d
-__NOXIMSELECTION_BUFFER_LEVEL_H__	selectionStrategies/Selection_BUFFER_LEVEL.h	/^#define __NOXIMSELECTION_BUFFER_LEVEL_H__$/;"	d
-__NOXIMSELECTION_NOP_H__	selectionStrategies/Selection_NOP.h	/^#define __NOXIMSELECTION_NOP_H__$/;"	d
-__NOXIMSELECTION_RANDOM_H__	selectionStrategies/Selection_RANDOM.h	/^#define __NOXIMSELECTION_RANDOM_H__$/;"	d
-__NOXIMSTATS_H__	Stats.h	/^#define __NOXIMSTATS_H__$/;"	d
-__NOXIMTILE_H__	Tile.h	/^#define __NOXIMTILE_H__$/;"	d
-__NOXIMTLMINITIATOR_H__	Initiator.h	/^#define __NOXIMTLMINITIATOR_H__$/;"	d
-__NOXIMTLMTARGET_H__	Target.h	/^#define __NOXIMTLMTARGET_H__$/;"	d
-__TOKENRING_H__	TokenRing.h	/^#define __TOKENRING_H__$/;"	d
-__UTILS_H__	Utils.h	/^#define __UTILS_H__$/;"	d
+YouAreSwitch	Utils.h	/^inline bool YouAreSwitch(int id)$/;"	f
+_DATASTRUCS_H__	DataStructs.h	12;"	d
+__BUS_H__	Channel.h	12;"	d
+__MM_H__	MM.h	12;"	d
+__NOXIMBUFFER_H__	Buffer.h	12;"	d
+__NOXIMCONFIGURATIONMANAGER_H__	ConfigurationManager.h	13;"	d
+__NOXIMGLOBALPARAMS_H__	GlobalParams.h	13;"	d
+__NOXIMGLOBALROUTINGTABLE_H__	GlobalRoutingTable.h	11;"	d
+__NOXIMGLOBALSTATS_H__	GlobalStats.h	12;"	d
+__NOXIMGLOBALTRAFFIC_HARDCODING_H__	GlobalTrafficHardcoding.h	12;"	d
+__NOXIMGLOBALTRAFFIC_TABLE_H__	GlobalTrafficTable.h	12;"	d
+__NOXIMHUB_H__	Hub.h	12;"	d
+__NOXIMLOCALROUTINGTABLE_H__	LocalRoutingTable.h	12;"	d
+__NOXIMNOC_H__	NoC.h	12;"	d
+__NOXIMPOWER_H__	Power.h	12;"	d
+__NOXIMPROCESSINGELEMENT_H__	ProcessingElement.h	12;"	d
+__NOXIMRESERVATIONTABLE_H__	ReservationTable.h	12;"	d
+__NOXIMROUTER_H__	Router.h	12;"	d
+__NOXIMSTATS_H__	Stats.h	12;"	d
+__NOXIMTILE_H__	Tile.h	12;"	d
+__NOXIMTLMINITIATOR_H__	Initiator.h	12;"	d
+__NOXIMTLMTARGET_H__	Target.h	12;"	d
+__TOKENRING_H__	TokenRing.h	12;"	d
+__UTILS_H__	Utils.h	12;"	d
+_channel_id	Initiator.h	/^  int _channel_id;$/;"	m	struct:Initiator
 access	MM.h	/^  struct access$/;"	s	class:mm
 accountWirelessRxPower	Channel.cpp	/^void Channel::accountWirelessRxPower()$/;"	f	class:Channel
 addHub	Channel.cpp	/^void Channel::addHub(Hub* h)$/;"	f	class:Channel
@@ -265,11 +217,11 @@ antenna_buffer_front_pwr_d	Power.h	/^    double antenna_buffer_front_pwr_d;$/;"	
 antenna_buffer_pop_pwr_d	Power.h	/^    double antenna_buffer_pop_pwr_d;$/;"	m	class:Power
 antenna_buffer_push_pwr_d	Power.h	/^    double antenna_buffer_push_pwr_d;$/;"	m	class:Power
 antenna_buffer_pwr_s	Power.h	/^    double antenna_buffer_pwr_s;$/;"	m	class:Power
-apply	selectionStrategies/Selection_BUFFER_LEVEL.cpp	/^int Selection_BUFFER_LEVEL::apply(Router * router, const vector < int >&directions, const RouteData & route_data){$/;"	f	class:Selection_BUFFER_LEVEL
-apply	selectionStrategies/Selection_NOP.cpp	/^int Selection_NOP::apply(Router * router, const vector < int >&directions, const RouteData & route_data) {$/;"	f	class:Selection_NOP
-apply	selectionStrategies/Selection_RANDOM.cpp	/^int Selection_RANDOM::apply(Router * router, const vector < int >&directions, const RouteData & route_data){$/;"	f	class:Selection_RANDOM
+asciiMonitor	NoC.cpp	/^void NoC::asciiMonitor()$/;"	f	class:NoC
+ascii_monitor	GlobalParams.cpp	/^bool GlobalParams::ascii_monitor;$/;"	m	class:GlobalParams	file:
+ascii_monitor	GlobalParams.h	/^    static bool ascii_monitor;$/;"	m	struct:GlobalParams
 attachHub	TokenRing.cpp	/^void TokenRing::attachHub(int channel, int hub, sc_in<int>* hub_token_holder_port, sc_in<int>* hub_token_expiration_port, sc_inout<int>* hub_flag_port)$/;"	f	class:TokenRing
-attachedNodes	GlobalParams.h	/^    vector<int> attachedNodes;$/;"	m	struct:__anon2
+attachedNodes	GlobalParams.h	/^    vector<int> attachedNodes;$/;"	m	struct:__anon6
 attenuation2power	Power.cpp	/^double Power::attenuation2power(double attenuation)$/;"	f	class:Power
 attenuation_map	Power.h	/^    map< pair<int, int> , double>  attenuation_map;$/;"	m	class:Power
 available	DataStructs.h	/^    bool available;		\/\/ $/;"	m	struct:ChannelStatus
@@ -278,15 +230,15 @@ b_transport	Target.cpp	/^void Target::b_transport( tlm::tlm_generic_payload& tra
 basic_nullbuf	Utils.h	/^class basic_nullbuf: public std::basic_streambuf<cT, traits> {$/;"	c
 basic_onullstream	Utils.h	/^    basic_onullstream():$/;"	f	class:basic_onullstream
 basic_onullstream	Utils.h	/^class basic_onullstream: public std::basic_ostream<cT, traits> {$/;"	c
-ber	GlobalParams.h	/^    pair<double, double> ber;$/;"	m	struct:__anon1
+ber	GlobalParams.h	/^    pair<double, double> ber;$/;"	m	struct:__anon5
 biasingRx	Power.cpp	/^void Power::biasingRx()$/;"	f	class:Power
 biasingTx	Power.cpp	/^void Power::biasingTx()$/;"	f	class:Power
-breakdown	DataStructs.h	/^    PowerBreakdownEntry breakdown[NO_BREAKDOWN_ENTRIES_D+NO_BREAKDOWN_ENTRIES_S];$/;"	m	struct:__anon10
+breakdown	DataStructs.h	/^    PowerBreakdownEntry breakdown[NO_BREAKDOWN_ENTRIES_D+NO_BREAKDOWN_ENTRIES_S];$/;"	m	struct:__anon4
 buffer	Buffer.h	/^    queue < Flit > buffer;$/;"	m	class:Buffer
 bufferFromTileFront	Power.cpp	/^void Power::bufferFromTileFront()$/;"	f	class:Power
 bufferFromTilePop	Power.cpp	/^void Power::bufferFromTilePop()$/;"	f	class:Power
 bufferFromTilePush	Power.cpp	/^void Power::bufferFromTilePush()$/;"	f	class:Power
-bufferPowerConfig	GlobalParams.h	/^    BufferPowerConfig bufferPowerConfig;$/;"	m	struct:__anon6
+bufferPowerConfig	GlobalParams.h	/^    BufferPowerConfig bufferPowerConfig;$/;"	m	struct:__anon10
 bufferRouterFront	Power.cpp	/^void Power::bufferRouterFront()$/;"	f	class:Power
 bufferRouterPop	Power.cpp	/^void Power::bufferRouterPop()$/;"	f	class:Power
 bufferRouterPush	Power.cpp	/^void Power::bufferRouterPush()$/;"	f	class:Power
@@ -309,11 +261,17 @@ buffer_to_tile_pop_pwr_d	Power.h	/^    double buffer_to_tile_pop_pwr_d;$/;"	m	cl
 buffer_to_tile_push_pwr_d	Power.h	/^    double buffer_to_tile_push_pwr_d;$/;"	m	class:Power
 buffer_to_tile_pwr_s	Power.h	/^    double buffer_to_tile_pwr_s;$/;"	m	class:Power
 buffer_tx	Initiator.h	/^  Buffer buffer_tx;$/;"	m	struct:Initiator
+buildBaseline	NoC.cpp	/^void NoC::buildBaseline()$/;"	f	class:NoC
+buildButterfly	NoC.cpp	/^void NoC::buildButterfly()$/;"	f	class:NoC
+buildCommon	NoC.cpp	/^void NoC::buildCommon()$/;"	f	class:NoC
 buildMesh	NoC.cpp	/^void NoC::buildMesh()$/;"	f	class:NoC
+buildOmega	NoC.cpp	/^void NoC::buildOmega()$/;"	f	class:NoC
 canShot	ProcessingElement.cpp	/^bool ProcessingElement::canShot(Packet & packet)$/;"	f	class:ProcessingElement
 cc_flit_transmission_delay_ps	Channel.h	/^      int cc_flit_transmission_delay_ps; \/\/ clock compliant$/;"	m	struct:Channel
 channel_configuration	GlobalParams.cpp	/^map<int, ChannelConfig> GlobalParams::channel_configuration;$/;"	m	class:GlobalParams	file:
 channel_configuration	GlobalParams.h	/^    static map<int, ChannelConfig> channel_configuration;$/;"	m	struct:GlobalParams
+channel_selection	GlobalParams.cpp	/^int GlobalParams::channel_selection;$/;"	m	class:GlobalParams	file:
+channel_selection	GlobalParams.h	/^    static int channel_selection;$/;"	m	struct:GlobalParams
 channel_status_neighbor	DataStructs.h	/^    ChannelStatus channel_status_neighbor[DIRECTIONS];$/;"	m	struct:NoP_data
 checkConfiguration	ConfigurationManager.cpp	/^void checkConfiguration()$/;"	f
 checkReservation	ReservationTable.cpp	/^int ReservationTable::checkReservation(const TReservation r, const int port_out)$/;"	f	class:ReservationTable
@@ -330,6 +288,7 @@ configure	Router.cpp	/^void Router::configure(const int _id,$/;"	f	class:Router
 configure	Stats.cpp	/^void Stats::configure(const int node_id, const double _warm_up_time)$/;"	f	class:Stats
 configureHub	Power.cpp	/^void Power::configureHub(int link_width,$/;"	f	class:Power
 configureRouter	Power.cpp	/^void Power::configureRouter(int link_width,$/;"	f	class:Power
+connectedHubs	Router.cpp	/^bool Router::connectedHubs(int src_hub, int dst_hub) {$/;"	f	class:Router
 convert	ConfigurationManager.h	/^    struct convert<BufferPowerConfig> {$/;"	s	namespace:YAML
 convert	ConfigurationManager.h	/^    struct convert<ChannelConfig> {$/;"	s	namespace:YAML
 convert	ConfigurationManager.h	/^    struct convert<HubConfig> {$/;"	s	namespace:YAML
@@ -339,12 +298,13 @@ convert	ConfigurationManager.h	/^    struct convert<PowerConfig> {$/;"	s	namespa
 convert	ConfigurationManager.h	/^    struct convert<RouterPowerConfig> {$/;"	s	namespace:YAML
 coord2Id	Utils.h	/^inline int coord2Id(const Coord & coord)$/;"	f
 crossBar	Power.cpp	/^void Power::crossBar()$/;"	f	class:Power
-crossbar_pm	GlobalParams.h	/^    map<pair<double, double>, pair<double, double> > crossbar_pm;$/;"	m	struct:__anon4
+crossbar_pm	GlobalParams.h	/^    map<pair<double, double>, pair<double, double> > crossbar_pm;$/;"	m	struct:__anon8
 crossbar_pwr_d	Power.h	/^    double crossbar_pwr_d;$/;"	m	class:Power
 crossbar_pwr_s	Power.h	/^    double crossbar_pwr_s;$/;"	m	class:Power
+current_hub_relay	Initiator.h	/^  int current_hub_relay;$/;"	m	struct:Initiator
 current_id	DataStructs.h	/^    int current_id;$/;"	m	struct:RouteData
 data	DataStructs.h	/^    sc_uint<32> data;	\/\/ Bus for the data to be exchanged$/;"	m	struct:Payload
-dataRate	GlobalParams.h	/^    int dataRate;$/;"	m	struct:__anon1
+dataRate	GlobalParams.h	/^    int dataRate;$/;"	m	struct:__anon5
 deadlockCheck	Buffer.cpp	/^void Buffer::deadlockCheck()$/;"	f	class:Buffer
 deadlockFree	Buffer.cpp	/^bool Buffer::deadlockFree()$/;"	f	class:Buffer
 deadlock_detected	Buffer.h	/^    bool deadlock_detected;$/;"	m	class:Buffer
@@ -360,7 +320,7 @@ default_channel_configuration	GlobalParams.cpp	/^ChannelConfig GlobalParams::def
 default_channel_configuration	GlobalParams.h	/^    static ChannelConfig default_channel_configuration;$/;"	m	struct:GlobalParams
 default_hub_configuration	GlobalParams.cpp	/^HubConfig GlobalParams::default_hub_configuration;$/;"	m	class:GlobalParams	file:
 default_hub_configuration	GlobalParams.h	/^    static HubConfig default_hub_configuration;$/;"	m	struct:GlobalParams
-default_tx_energy	GlobalParams.h	/^    double default_tx_energy;$/;"	m	struct:__anon5
+default_tx_energy	GlobalParams.h	/^    double default_tx_energy;$/;"	m	struct:__anon9
 default_tx_energy	Power.h	/^    double default_tx_energy;$/;"	m	class:Power
 delays	Stats.h	/^     vector < double >delays;$/;"	m	struct:CommHistory
 detailed	GlobalParams.cpp	/^bool GlobalParams::detailed;$/;"	m	class:GlobalParams	file:
@@ -369,6 +329,7 @@ dir_in	DataStructs.h	/^    int dir_in;			\/\/ direction from which the packet co
 direction2ILinkId	GlobalRoutingTable.cpp	/^LinkId direction2ILinkId(const int node_id, const int dir)$/;"	f
 drained_total	GlobalStats.h	/^    unsigned int drained_total;$/;"	m	class:GlobalStats
 drained_volume	Main.cpp	/^unsigned int drained_volume;$/;"	v
+dst	GlobalTrafficHardcoding.h	/^  int dst;			\/\/ ID of the destination node (PE)$/;"	m	struct:HardcodedTrafficEntry
 dst	GlobalTrafficTable.h	/^  int dst;			\/\/ ID of the destination node (PE)$/;"	m	struct:Communication
 dst_id	DataStructs.h	/^    int dst_id;$/;"	m	struct:Flit
 dst_id	DataStructs.h	/^    int dst_id;$/;"	m	struct:Packet
@@ -392,12 +353,10 @@ flit_type	DataStructs.h	/^    FlitType flit_type;	\/\/ The flit type (FLIT_TYPE_
 free	MM.cpp	/^void mm::free(gp_t* trans)$/;"	f	class:mm
 free_list	MM.h	/^  access* free_list;$/;"	m	class:mm
 free_slots	DataStructs.h	/^    int free_slots;		\/\/ occupied buffer slots$/;"	m	struct:ChannelStatus
-fromTileBufferSize	GlobalParams.h	/^    int fromTileBufferSize;$/;"	m	struct:__anon2
+fromTileBufferSize	GlobalParams.h	/^    int fromTileBufferSize;$/;"	m	struct:__anon6
 from_hub	NoC.h	/^    sc_signal<T> from_hub;$/;"	m	struct:sc_signal_NSWEH
-front	GlobalParams.h	/^    map<pair <int, int>, double> front;$/;"	m	struct:__anon3
+front	GlobalParams.h	/^    map<pair <int, int>, double> front;$/;"	m	struct:__anon7
 full_cycles_counter	Buffer.h	/^    int full_cycles_counter;$/;"	m	class:Buffer
-get	routingAlgorithms/RoutingAlgorithms.cpp	/^RoutingAlgorithm * RoutingAlgorithms::get(const string & routingAlgorithmName) {$/;"	f	class:RoutingAlgorithms
-get	selectionStrategies/SelectionStrategies.cpp	/^SelectionStrategy * SelectionStrategies::get(const string & selectionStrategyName) {$/;"	f	class:SelectionStrategies
 getActiveThroughput	GlobalStats.cpp	/^double GlobalStats::getActiveThroughput()$/;"	f	class:GlobalStats
 getAdmissibleOutputs	LocalRoutingTable.cpp	/^getAdmissibleOutputs(const LinkId & in_link, const int destination_id)$/;"	f	class:LocalRoutingTable
 getAdmissibleOutputs	LocalRoutingTable.cpp	/^getAdmissibleOutputs(const int in_direction, const int destination_id)$/;"	f	class:LocalRoutingTable
@@ -418,16 +377,6 @@ getDynamicPower	GlobalStats.cpp	/^double GlobalStats::getDynamicPower()$/;"	f	cl
 getDynamicPower	Power.cpp	/^double Power::getDynamicPower()$/;"	f	class:Power
 getDynamicPowerBreakDown	Power.h	/^    PowerBreakdown* getDynamicPowerBreakDown(){ return &power_dynamic;}$/;"	f	class:Power
 getFlitTransmissionCycles	Channel.h	/^  int getFlitTransmissionCycles() { return flit_transmission_cycles;}$/;"	f	struct:Channel
-getInstance	routingAlgorithms/Routing_DYAD.cpp	/^Routing_DYAD * Routing_DYAD::getInstance() {$/;"	f	class:Routing_DYAD
-getInstance	routingAlgorithms/Routing_NEGATIVE_FIRST.cpp	/^Routing_NEGATIVE_FIRST * Routing_NEGATIVE_FIRST::getInstance() {$/;"	f	class:Routing_NEGATIVE_FIRST
-getInstance	routingAlgorithms/Routing_NORTH_LAST.cpp	/^Routing_NORTH_LAST * Routing_NORTH_LAST::getInstance() {$/;"	f	class:Routing_NORTH_LAST
-getInstance	routingAlgorithms/Routing_ODD_EVEN.cpp	/^Routing_ODD_EVEN * Routing_ODD_EVEN::getInstance() {$/;"	f	class:Routing_ODD_EVEN
-getInstance	routingAlgorithms/Routing_TABLE_BASED.cpp	/^Routing_TABLE_BASED * Routing_TABLE_BASED::getInstance() {$/;"	f	class:Routing_TABLE_BASED
-getInstance	routingAlgorithms/Routing_WEST_FIRST.cpp	/^Routing_WEST_FIRST * Routing_WEST_FIRST::getInstance() {$/;"	f	class:Routing_WEST_FIRST
-getInstance	routingAlgorithms/Routing_XY.cpp	/^Routing_XY * Routing_XY::getInstance() {$/;"	f	class:Routing_XY
-getInstance	selectionStrategies/Selection_BUFFER_LEVEL.cpp	/^Selection_BUFFER_LEVEL * Selection_BUFFER_LEVEL::getInstance() {$/;"	f	class:Selection_BUFFER_LEVEL
-getInstance	selectionStrategies/Selection_NOP.cpp	/^Selection_NOP * Selection_NOP::getInstance() {$/;"	f	class:Selection_NOP
-getInstance	selectionStrategies/Selection_RANDOM.cpp	/^Selection_RANDOM * Selection_RANDOM::getInstance() {$/;"	f	class:Selection_RANDOM
 getLabel	Buffer.cpp	/^string Buffer::getLabel() const$/;"	f	class:Buffer
 getMaxDelay	GlobalStats.cpp	/^double GlobalStats::getMaxDelay()$/;"	f	class:GlobalStats
 getMaxDelay	GlobalStats.cpp	/^double GlobalStats::getMaxDelay(const int node_id)$/;"	f	class:GlobalStats
@@ -437,16 +386,16 @@ getMaxDelay	Stats.cpp	/^double Stats::getMaxDelay(const int src_id)$/;"	f	class:
 getMaxDelayMtx	GlobalStats.cpp	/^vector < vector < double > > GlobalStats::getMaxDelayMtx()$/;"	f	class:GlobalStats
 getNeighborId	Router.cpp	/^int Router::getNeighborId(int _id, int direction) const$/;"	f	class:Router
 getNodeRoutingTable	GlobalRoutingTable.cpp	/^getNodeRoutingTable(const int node_id)$/;"	f	class:GlobalRoutingTable
+getQueueSize	ProcessingElement.cpp	/^unsigned int ProcessingElement::getQueueSize() const$/;"	f	class:ProcessingElement
 getRandomSize	ProcessingElement.cpp	/^int ProcessingElement::getRandomSize()$/;"	f	class:ProcessingElement
 getReceivedFlits	GlobalStats.cpp	/^unsigned int GlobalStats::getReceivedFlits()$/;"	f	class:GlobalStats
 getReceivedFlits	Stats.cpp	/^unsigned int Stats::getReceivedFlits()$/;"	f	class:Stats
+getReceivedIdealFlitRatio	GlobalStats.cpp	/^double GlobalStats::getReceivedIdealFlitRatio()$/;"	f	class:GlobalStats
 getReceivedPackets	GlobalStats.cpp	/^unsigned int GlobalStats::getReceivedPackets()$/;"	f	class:GlobalStats
 getReceivedPackets	Stats.cpp	/^unsigned int Stats::getReceivedPackets()$/;"	f	class:Stats
 getReservations	ReservationTable.cpp	/^vector<pair<int,int> > ReservationTable::getReservations(const int port_in)$/;"	f	class:ReservationTable
 getRoutedFlits	Router.cpp	/^unsigned long Router::getRoutedFlits()$/;"	f	class:Router
 getRoutedFlitsMtx	GlobalStats.cpp	/^vector < vector < unsigned long > > GlobalStats::getRoutedFlitsMtx()$/;"	f	class:GlobalStats
-getRoutingAlgorithmsMap	routingAlgorithms/RoutingAlgorithms.cpp	/^RoutingAlgorithmsMap * RoutingAlgorithms::getRoutingAlgorithmsMap() {$/;"	f	class:RoutingAlgorithms
-getSelectionStrategiesMap	selectionStrategies/SelectionStrategies.cpp	/^SelectionStrategiesMap * SelectionStrategies::getSelectionStrategiesMap() {$/;"	f	class:SelectionStrategies
 getStaticPower	GlobalStats.cpp	/^double GlobalStats::getStaticPower()$/;"	f	class:GlobalStats
 getStaticPower	Power.cpp	/^double Power::getStaticPower()$/;"	f	class:Power
 getStaticPowerBreakDown	Power.h	/^    PowerBreakdown* getStaticPowerBreakDown(){ return &power_static;}$/;"	f	class:Power
@@ -465,18 +414,19 @@ hotspots	GlobalParams.cpp	/^vector <pair <int, double> > GlobalParams::hotspots;
 hotspots	GlobalParams.h	/^    static vector <pair <int, double> > hotspots;$/;"	m	struct:GlobalParams
 hub	Initiator.h	/^  Hub * hub;$/;"	m	struct:Initiator
 hub	Target.h	/^  Hub* hub;$/;"	m	struct:Target
-hubPowerConfig	GlobalParams.h	/^    HubPowerConfig hubPowerConfig;$/;"	m	struct:__anon6
+hubPowerConfig	GlobalParams.h	/^    HubPowerConfig hubPowerConfig;$/;"	m	struct:__anon10
 hub_configuration	GlobalParams.cpp	/^map<int, HubConfig> GlobalParams::hub_configuration;$/;"	m	class:GlobalParams	file:
 hub_configuration	GlobalParams.h	/^    static map<int, HubConfig> hub_configuration;$/;"	m	struct:GlobalParams
 hub_for_tile	GlobalParams.cpp	/^map<int, int> GlobalParams::hub_for_tile;$/;"	m	class:GlobalParams	file:
 hub_for_tile	GlobalParams.h	/^    static map<int, int> hub_for_tile;$/;"	m	struct:GlobalParams
+hub_relay_node	DataStructs.h	/^    int hub_relay_node;$/;"	m	struct:Flit
 hubs	Channel.h	/^    vector<Hub*> hubs;$/;"	m	struct:Channel
 hubs_id	Channel.h	/^    vector<int> hubs_id;$/;"	m	struct:Channel
 i_to_string	Utils.h	/^template<typename T> std::string i_to_string(const T& t){$/;"	f
 id	Stats.h	/^    int id;$/;"	m	class:Stats
 id2Coord	Utils.h	/^inline Coord id2Coord(int id)$/;"	f
 inCongestion	Router.cpp	/^bool Router::inCongestion()$/;"	f	class:Router
-index	ReservationTable.h	/^    int index;$/;"	m	struct:RTEntry
+index	ReservationTable.h	/^    vector<TReservation>::size_type index;$/;"	m	struct:RTEntry
 initPowerBreakdown	Power.cpp	/^void Power::initPowerBreakdown()$/;"	f	class:Power
 initPowerBreakdownEntry	Power.cpp	/^void Power::initPowerBreakdownEntry(PowerBreakdownEntry* pbe,string label)$/;"	f	class:Power
 init_socket	Channel.h	/^  tlm_utils::multi_passthrough_initiator_socket<Channel> init_socket;$/;"	m	struct:Channel
@@ -486,11 +436,11 @@ isNotReserved	ReservationTable.cpp	/^bool ReservationTable::isNotReserved(const 
 isSleeping	Power.cpp	/^bool Power::isSleeping()$/;"	f	class:Power
 isValid	GlobalRoutingTable.h	/^    bool isValid() {$/;"	f	class:GlobalRoutingTable
 label	Buffer.h	/^    string label;$/;"	m	class:Buffer
-label	DataStructs.h	/^    string label;$/;"	m	struct:__anon7
+label	DataStructs.h	/^    string label;$/;"	m	struct:__anon1
 last_event	Buffer.h	/^    double hold_time, last_event, hold_time_sum;$/;"	m	class:Buffer
 last_front_flit_seq	Buffer.h	/^    int last_front_flit_seq;$/;"	m	class:Buffer
 last_received_flit_time	Stats.h	/^    double last_received_flit_time;$/;"	m	struct:CommHistory
-leakage	GlobalParams.h	/^    map<pair <int, int>, double> leakage;$/;"	m	struct:__anon3
+leakage	GlobalParams.h	/^    map<pair <int, int>, double> leakage;$/;"	m	struct:__anon7
 leakageAntennaBuffer	Power.cpp	/^void Power::leakageAntennaBuffer()$/;"	f	class:Power
 leakageBufferFromTile	Power.cpp	/^void Power::leakageBufferFromTile()$/;"	f	class:Power
 leakageBufferRouter	Power.cpp	/^void Power::leakageBufferRouter()$/;"	f	class:Power
@@ -500,12 +450,13 @@ leakageLinkRouter2Router	Power.cpp	/^void Power::leakageLinkRouter2Router()$/;"	
 leakageRouter	Power.cpp	/^void Power::leakageRouter()$/;"	f	class:Power
 leakageTransceiverRx	Power.cpp	/^void Power::leakageTransceiverRx()$/;"	f	class:Power
 leakageTransceiverTx	Power.cpp	/^void Power::leakageTransceiverTx()$/;"	f	class:Power
-linkBitLinePowerConfig	GlobalParams.h	/^    LinkBitLinePowerConfig linkBitLinePowerConfig;$/;"	m	struct:__anon6
+linkBitLinePowerConfig	GlobalParams.h	/^    LinkBitLinePowerConfig linkBitLinePowerConfig;$/;"	m	struct:__anon10
 link_r2h_pwr_d	Power.h	/^    double link_r2h_pwr_d;$/;"	m	class:Power
 link_r2h_pwr_s	Power.h	/^    double link_r2h_pwr_s;$/;"	m	class:Power
 link_r2r_pwr_d	Power.h	/^    double link_r2r_pwr_d;$/;"	m	class:Power
 link_r2r_pwr_s	Power.h	/^    double link_r2r_pwr_s;$/;"	m	class:Power
 load	GlobalRoutingTable.cpp	/^bool GlobalRoutingTable::load(const char *fname)$/;"	f	class:GlobalRoutingTable
+load	GlobalTrafficHardcoding.cpp	/^bool GlobalTrafficHardcoding::load(const char *fname)$/;"	f	class:GlobalTrafficHardcoding
 load	GlobalTrafficTable.cpp	/^bool GlobalTrafficTable::load(const char *fname)$/;"	f	class:GlobalTrafficTable
 loadConfiguration	ConfigurationManager.cpp	/^void loadConfiguration() {$/;"	f
 local_id	Channel.h	/^  int local_id; \/\/ Unique ID$/;"	m	struct:Channel
@@ -515,7 +466,7 @@ locality	GlobalParams.h	/^    static double locality;$/;"	m	struct:GlobalParams
 log2ceil	ProcessingElement.cpp	/^inline double ProcessingElement::log2ceil(double x)$/;"	f	class:ProcessingElement
 m_id_map	Channel.h	/^  std::map <tlm::tlm_generic_payload*, unsigned int> m_id_map;$/;"	m	struct:Channel
 m_sbuf	Utils.h	/^    basic_nullbuf<cT, traits> m_sbuf;$/;"	m	class:basic_onullstream
-macPolicy	GlobalParams.h	/^    vector<string> macPolicy;$/;"	m	struct:__anon1
+macPolicy	GlobalParams.h	/^    vector<string> macPolicy;$/;"	m	struct:__anon5
 make	DataStructs.h	/^    void make(const int s, const int d, const int vc, const double ts, const int sz) {$/;"	f	struct:Packet
 mask	DataStructs.h	/^    bool mask[MAX_VIRTUAL_CHANNELS];$/;"	m	struct:TBufferFullStatus
 max_buffer_size	Buffer.h	/^    unsigned int max_buffer_size;$/;"	m	class:Buffer
@@ -535,16 +486,17 @@ min_packet_size	GlobalParams.h	/^    static int min_packet_size;$/;"	m	struct:Gl
 mm	MM.h	/^  mm() : free_list(0), empties(0) {}$/;"	f	class:mm
 mm	MM.h	/^class mm: public tlm::tlm_mm_interface$/;"	c
 n	Main.cpp	/^NoC *n;$/;"	v
+n_delta_tiles	GlobalParams.cpp	/^int GlobalParams::n_delta_tiles;$/;"	m	class:GlobalParams	file:
+n_delta_tiles	GlobalParams.h	/^    static int n_delta_tiles;$/;"	m	struct:GlobalParams
 n_outputs	ReservationTable.h	/^     int n_outputs;$/;"	m	class:ReservationTable
 n_trans	Target.h	/^  int   n_trans;$/;"	m	struct:Target
 n_virtual_channels	GlobalParams.cpp	/^int GlobalParams::n_virtual_channels;$/;"	m	class:GlobalParams	file:
 n_virtual_channels	GlobalParams.h	/^    static int n_virtual_channels;$/;"	m	struct:GlobalParams
 name	ReservationTable.h	/^    inline string name() const {return "ReservationTable";};$/;"	f	class:ReservationTable
-name	routingAlgorithms/Routing_ODD_EVEN.h	/^        inline string name() { return "Routing_ODD_EVEN";};$/;"	f	class:Routing_ODD_EVEN
-name	routingAlgorithms/Routing_TABLE_BASED.h	/^        inline string name() { return "Routing_TABLE_BASED";};$/;"	f	class:Routing_TABLE_BASED
 networkInterface	Power.cpp	/^void Power::networkInterface()$/;"	f	class:Power
-network_interface	GlobalParams.h	/^    map<int, pair<double, double> > network_interface;$/;"	m	struct:__anon4
+network_interface	GlobalParams.h	/^    map<int, pair<double, double> > network_interface;$/;"	m	struct:__anon8
 next	MM.h	/^    access* next;$/;"	m	struct:mm::access
+nextDeltaHops	Router.cpp	/^vector<int> Router::nextDeltaHops(RouteData rd) {$/;"	f	class:Router
 nextFlit	ProcessingElement.cpp	/^Flit ProcessingElement::nextFlit()$/;"	f	class:ProcessingElement
 ni_pwr_d	Power.h	/^    double ni_pwr_d;$/;"	m	class:Power
 ni_pwr_s	Power.h	/^    double ni_pwr_s;$/;"	m	class:Power
@@ -552,10 +504,9 @@ noc	GlobalStats.h	/^    const NoC *noc;$/;"	m	class:GlobalStats
 node_id	LocalRoutingTable.h	/^    int node_id;$/;"	m	class:LocalRoutingTable
 north	NoC.h	/^    sc_signal<T> north;$/;"	m	struct:sc_signal_NSWE
 north	NoC.h	/^    sc_signal<T> north;$/;"	m	struct:sc_signal_NSWEH
+num_cycles	GlobalTrafficHardcoding.cpp	/^size_t GlobalTrafficHardcoding::num_cycles() const {$/;"	f	class:GlobalTrafficHardcoding
 oLinkId2Direction	GlobalRoutingTable.cpp	/^int oLinkId2Direction(const LinkId & out_link)$/;"	f
 occurrencesAsSource	GlobalTrafficTable.cpp	/^int GlobalTrafficTable::occurrencesAsSource(const int src_id)$/;"	f	class:GlobalTrafficTable
-odd_even	routingAlgorithms/Routing_DYAD.cpp	/^RoutingAlgorithm * Routing_DYAD::odd_even = 0;$/;"	m	class:Routing_DYAD	file:
-odd_even	routingAlgorithms/Routing_DYAD.h	/^        static RoutingAlgorithm * odd_even;$/;"	m	class:Routing_DYAD
 onullstream	Utils.h	/^typedef basic_onullstream<char> onullstream;$/;"	t
 operator <<	Utils.h	/^inline ostream & operator <<(ostream & os, const Coord & coord)$/;"	f
 operator <<	Utils.h	/^inline ostream & operator <<(ostream & os, const Flit & flit)$/;"	f
@@ -575,11 +526,8 @@ packet_injection_rate	GlobalParams.h	/^    static double packet_injection_rate;$
 parseCmdLine	ConfigurationManager.cpp	/^void parseCmdLine(int arg_num, char *arg_vet[])$/;"	f
 payload	DataStructs.h	/^    Payload payload;	\/\/ Optional payload$/;"	m	struct:Flit
 perCycleUpdate	Router.cpp	/^void Router::perCycleUpdate()$/;"	f	class:Router
-perCycleUpdate	selectionStrategies/Selection_BUFFER_LEVEL.cpp	/^void Selection_BUFFER_LEVEL::perCycleUpdate(Router * router) {$/;"	f	class:Selection_BUFFER_LEVEL
-perCycleUpdate	selectionStrategies/Selection_NOP.cpp	/^void Selection_NOP::perCycleUpdate(Router * router) {$/;"	f	class:Selection_NOP
-perCycleUpdate	selectionStrategies/Selection_RANDOM.cpp	/^void Selection_RANDOM::perCycleUpdate(Router * router){ }$/;"	f	class:Selection_RANDOM
 pir	GlobalTrafficTable.h	/^  double pir;			\/\/ Packet Injection Rate for the link$/;"	m	struct:Communication
-pop	GlobalParams.h	/^    map<pair <int, int>, double> pop;$/;"	m	struct:__anon3
+pop	GlobalParams.h	/^    map<pair <int, int>, double> pop;$/;"	m	struct:__anon7
 por	GlobalTrafficTable.h	/^  double por;			\/\/ Probability Of Retransmission for the link$/;"	m	struct:Communication
 power	Channel.h	/^  Power power;$/;"	m	struct:Channel
 powerManager	Channel.cpp	/^void Channel::powerManager(unsigned int hub_dst_index, tlm::tlm_generic_payload& trans)$/;"	f	class:Channel
@@ -598,7 +546,7 @@ printMap	Utils.h	/^inline void printMap(string label, const map<string,double> &
 probability_of_retransmission	GlobalParams.cpp	/^double GlobalParams::probability_of_retransmission;$/;"	m	class:GlobalParams	file:
 probability_of_retransmission	GlobalParams.h	/^    static double probability_of_retransmission;$/;"	m	struct:GlobalParams
 process	Router.cpp	/^void Router::process()$/;"	f	class:Router
-push	GlobalParams.h	/^    map<pair <int, int>, double> push;$/;"	m	struct:__anon3
+push	GlobalParams.h	/^    map<pair <int, int>, double> push;$/;"	m	struct:__anon7
 r2hLink	Power.cpp	/^void Power::r2hLink()$/;"	f	class:Power
 r2h_link_length	GlobalParams.cpp	/^double GlobalParams::r2h_link_length;$/;"	m	class:GlobalParams	file:
 r2h_link_length	GlobalParams.h	/^    static double r2h_link_length;$/;"	m	struct:GlobalParams
@@ -606,6 +554,8 @@ r2rLink	Power.cpp	/^void Power::r2rLink()$/;"	f	class:Power
 r2r_link_length	GlobalParams.cpp	/^double GlobalParams::r2r_link_length;$/;"	m	class:GlobalParams	file:
 r2r_link_length	GlobalParams.h	/^    static double r2r_link_length;$/;"	m	struct:GlobalParams
 randInt	ProcessingElement.cpp	/^int ProcessingElement::randInt(int min, int max)$/;"	f	class:ProcessingElement
+readParam	ConfigurationManager.cpp	/^T readParam(YAML::Node node, string param) {$/;"	f
+readParam	ConfigurationManager.cpp	/^T readParam(YAML::Node node, string param, T default_value) {$/;"	f
 receivedFlit	Stats.cpp	/^void Stats::receivedFlit(const double arrival_time,$/;"	f	class:Stats
 reflexDirection	Router.cpp	/^int Router::reflexDirection(int direction) const$/;"	f	class:Router
 release	ReservationTable.cpp	/^void ReservationTable::release(const TReservation r, const int port_out)$/;"	f	class:ReservationTable
@@ -619,42 +569,12 @@ rnd_generator_seed	GlobalParams.h	/^    static int rnd_generator_seed;$/;"	m	str
 roulette	ProcessingElement.cpp	/^int roulette()$/;"	f
 route	Hub.cpp	/^int Hub::route(Flit& f)$/;"	f	class:Hub
 route	Router.cpp	/^int Router::route(const RouteData & route_data)$/;"	f	class:Router
-route	routingAlgorithms/Routing_DYAD.cpp	/^vector<int> Routing_DYAD::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_DYAD
-route	routingAlgorithms/Routing_NEGATIVE_FIRST.cpp	/^vector<int> Routing_NEGATIVE_FIRST::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_NEGATIVE_FIRST
-route	routingAlgorithms/Routing_NORTH_LAST.cpp	/^vector<int> Routing_NORTH_LAST::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_NORTH_LAST
-route	routingAlgorithms/Routing_ODD_EVEN.cpp	/^vector<int> Routing_ODD_EVEN::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_ODD_EVEN
-route	routingAlgorithms/Routing_TABLE_BASED.cpp	/^vector<int> Routing_TABLE_BASED::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_TABLE_BASED
-route	routingAlgorithms/Routing_WEST_FIRST.cpp	/^vector<int> Routing_WEST_FIRST::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_WEST_FIRST
-route	routingAlgorithms/Routing_XY.cpp	/^vector<int> Routing_XY::route(Router * router, const RouteData & routeData)$/;"	f	class:Routing_XY
-routerPowerConfig	GlobalParams.h	/^    RouterPowerConfig routerPowerConfig;$/;"	m	struct:__anon6
+routerPowerConfig	GlobalParams.h	/^    RouterPowerConfig routerPowerConfig;$/;"	m	struct:__anon10
 routing	Power.cpp	/^void Power::routing()$/;"	f	class:Power
-routingAlgorithmsMap	routingAlgorithms/RoutingAlgorithms.cpp	/^RoutingAlgorithmsMap * RoutingAlgorithms::routingAlgorithmsMap = 0;$/;"	m	class:RoutingAlgorithms	file:
-routingAlgorithmsMap	routingAlgorithms/RoutingAlgorithms.h	/^		static RoutingAlgorithmsMap * routingAlgorithmsMap;$/;"	m	class:RoutingAlgorithms
-routingAlgorithmsRegister	routingAlgorithms/Routing_DYAD.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_DYAD
-routingAlgorithmsRegister	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_NEGATIVE_FIRST
-routingAlgorithmsRegister	routingAlgorithms/Routing_NORTH_LAST.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_NORTH_LAST
-routingAlgorithmsRegister	routingAlgorithms/Routing_ODD_EVEN.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_ODD_EVEN
-routingAlgorithmsRegister	routingAlgorithms/Routing_TABLE_BASED.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_TABLE_BASED
-routingAlgorithmsRegister	routingAlgorithms/Routing_WEST_FIRST.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_WEST_FIRST
-routingAlgorithmsRegister	routingAlgorithms/Routing_XY.h	/^		static RoutingAlgorithmsRegister routingAlgorithmsRegister;$/;"	m	class:Routing_XY
 routingFunction	Router.cpp	/^vector < int > Router::routingFunction(const RouteData & route_data)$/;"	f	class:Router
-routing_DYAD	routingAlgorithms/Routing_DYAD.cpp	/^Routing_DYAD * Routing_DYAD::routing_DYAD = 0;$/;"	m	class:Routing_DYAD	file:
-routing_DYAD	routingAlgorithms/Routing_DYAD.h	/^		static Routing_DYAD * routing_DYAD;$/;"	m	class:Routing_DYAD
-routing_NEGATIVE_FIRST	routingAlgorithms/Routing_NEGATIVE_FIRST.cpp	/^Routing_NEGATIVE_FIRST * Routing_NEGATIVE_FIRST::routing_NEGATIVE_FIRST = 0;$/;"	m	class:Routing_NEGATIVE_FIRST	file:
-routing_NEGATIVE_FIRST	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^		static Routing_NEGATIVE_FIRST * routing_NEGATIVE_FIRST;$/;"	m	class:Routing_NEGATIVE_FIRST
-routing_NORTH_LAST	routingAlgorithms/Routing_NORTH_LAST.cpp	/^Routing_NORTH_LAST * Routing_NORTH_LAST::routing_NORTH_LAST = 0;$/;"	m	class:Routing_NORTH_LAST	file:
-routing_NORTH_LAST	routingAlgorithms/Routing_NORTH_LAST.h	/^		static Routing_NORTH_LAST * routing_NORTH_LAST;$/;"	m	class:Routing_NORTH_LAST
-routing_ODD_EVEN	routingAlgorithms/Routing_ODD_EVEN.cpp	/^Routing_ODD_EVEN * Routing_ODD_EVEN::routing_ODD_EVEN = 0;$/;"	m	class:Routing_ODD_EVEN	file:
-routing_ODD_EVEN	routingAlgorithms/Routing_ODD_EVEN.h	/^		static Routing_ODD_EVEN * routing_ODD_EVEN;$/;"	m	class:Routing_ODD_EVEN
-routing_TABLE_BASED	routingAlgorithms/Routing_TABLE_BASED.cpp	/^Routing_TABLE_BASED * Routing_TABLE_BASED::routing_TABLE_BASED = 0;$/;"	m	class:Routing_TABLE_BASED	file:
-routing_TABLE_BASED	routingAlgorithms/Routing_TABLE_BASED.h	/^		static Routing_TABLE_BASED * routing_TABLE_BASED;$/;"	m	class:Routing_TABLE_BASED
-routing_WEST_FIRST	routingAlgorithms/Routing_WEST_FIRST.cpp	/^Routing_WEST_FIRST * Routing_WEST_FIRST::routing_WEST_FIRST = 0;$/;"	m	class:Routing_WEST_FIRST	file:
-routing_WEST_FIRST	routingAlgorithms/Routing_WEST_FIRST.h	/^		static Routing_WEST_FIRST * routing_WEST_FIRST;$/;"	m	class:Routing_WEST_FIRST
-routing_XY	routingAlgorithms/Routing_XY.cpp	/^Routing_XY * Routing_XY::routing_XY = 0;$/;"	m	class:Routing_XY	file:
-routing_XY	routingAlgorithms/Routing_XY.h	/^		static Routing_XY * routing_XY;$/;"	m	class:Routing_XY
 routing_algorithm	GlobalParams.cpp	/^string GlobalParams::routing_algorithm;$/;"	m	class:GlobalParams	file:
 routing_algorithm	GlobalParams.h	/^    static string routing_algorithm;$/;"	m	struct:GlobalParams
-routing_algorithm_pm	GlobalParams.h	/^    map<string, pair<double, double> > routing_algorithm_pm;$/;"	m	struct:__anon4
+routing_algorithm_pm	GlobalParams.h	/^    map<string, pair<double, double> > routing_algorithm_pm;$/;"	m	struct:__anon8
 routing_pwr_d	Power.h	/^    double routing_pwr_d;$/;"	m	class:Power
 routing_pwr_s	Power.h	/^    double routing_pwr_s;$/;"	m	class:Power
 routing_table_filename	GlobalParams.cpp	/^string GlobalParams::routing_table_filename;$/;"	m	class:GlobalParams	file:
@@ -662,14 +582,14 @@ routing_table_filename	GlobalParams.h	/^    static string routing_table_filename
 rt_noc	GlobalRoutingTable.h	/^     RoutingTableNoC rt_noc;$/;"	m	class:GlobalRoutingTable
 rt_node	LocalRoutingTable.h	/^     RoutingTableNode rt_node;$/;"	m	class:LocalRoutingTable
 rtable	ReservationTable.h	/^     TRTEntry *rtable;	\/\/ reservation vector: rtable[i] gives a RTEntry containing the set of input\/VC $/;"	m	class:ReservationTable
-rxBufferSize	GlobalParams.h	/^    int rxBufferSize;$/;"	m	struct:__anon2
-rxChannels	GlobalParams.h	/^    vector<int> rxChannels;$/;"	m	struct:__anon2
+rxBufferSize	GlobalParams.h	/^    int rxBufferSize;$/;"	m	struct:__anon6
+rxChannels	GlobalParams.h	/^    vector<int> rxChannels;$/;"	m	struct:__anon6
 rxPowerManager	Hub.cpp	/^void Hub::rxPowerManager()$/;"	f	class:Hub
 rxProcess	ProcessingElement.cpp	/^void ProcessingElement::rxProcess()$/;"	f	class:ProcessingElement
 rxProcess	Router.cpp	/^void Router::rxProcess()$/;"	f	class:Router
 rxSleep	Power.cpp	/^void Power::rxSleep(int cycles)$/;"	f	class:Power
-rx_dynamic	GlobalParams.h	/^    double rx_dynamic;$/;"	m	struct:__anon5
-rx_snooping	GlobalParams.h	/^    double rx_snooping;$/;"	m	struct:__anon5
+rx_dynamic	GlobalParams.h	/^    double rx_dynamic;$/;"	m	struct:__anon9
+rx_snooping	GlobalParams.h	/^    double rx_snooping;$/;"	m	struct:__anon9
 sameRadioHub	Utils.h	/^inline bool sameRadioHub(int id1, int id2)$/;"	f
 sc_main	Main.cpp	/^int sc_main(int arg_num, char *arg_vet[])$/;"	f
 sc_signal_NSWE	NoC.h	/^struct sc_signal_NSWE$/;"	s
@@ -680,25 +600,14 @@ sc_trace	Utils.h	/^inline void sc_trace(sc_trace_file * &tf, const NoP_data & No
 sc_trace	Utils.h	/^inline void sc_trace(sc_trace_file * &tf, const TBufferFullStatus & bfs, string & name)$/;"	f
 searchCommHistory	Stats.cpp	/^int Stats::searchCommHistory(int src_id)$/;"	f	class:Stats
 searchNode	NoC.cpp	/^Tile *NoC::searchNode(const int id) const$/;"	f	class:NoC
-selectChannel	Utils.h	/^inline int selectChannel(int src_hub, int dst_hub)$/;"	f
+selectChannel	Hub.cpp	/^int Hub::selectChannel(int src_hub, int dst_hub) const$/;"	f	class:Hub
 selection	Power.cpp	/^void Power::selection()$/;"	f	class:Power
 selectionFunction	Router.cpp	/^int Router::selectionFunction(const vector < int >&directions,$/;"	f	class:Router
-selectionStrategiesMap	selectionStrategies/SelectionStrategies.cpp	/^SelectionStrategiesMap * SelectionStrategies::selectionStrategiesMap = 0;$/;"	m	class:SelectionStrategies	file:
-selectionStrategiesMap	selectionStrategies/SelectionStrategies.h	/^		static SelectionStrategiesMap * selectionStrategiesMap;$/;"	m	class:SelectionStrategies
-selectionStrategiesRegister	selectionStrategies/Selection_BUFFER_LEVEL.h	/^		static SelectionStrategiesRegister selectionStrategiesRegister;$/;"	m	class:Selection_BUFFER_LEVEL
-selectionStrategiesRegister	selectionStrategies/Selection_NOP.h	/^		static SelectionStrategiesRegister selectionStrategiesRegister;$/;"	m	class:Selection_NOP
-selectionStrategiesRegister	selectionStrategies/Selection_RANDOM.h	/^		static SelectionStrategiesRegister selectionStrategiesRegister;$/;"	m	class:Selection_RANDOM
-selection_BUFFER_LEVEL	selectionStrategies/Selection_BUFFER_LEVEL.cpp	/^Selection_BUFFER_LEVEL * Selection_BUFFER_LEVEL::selection_BUFFER_LEVEL = 0;$/;"	m	class:Selection_BUFFER_LEVEL	file:
-selection_BUFFER_LEVEL	selectionStrategies/Selection_BUFFER_LEVEL.h	/^		static Selection_BUFFER_LEVEL * selection_BUFFER_LEVEL;$/;"	m	class:Selection_BUFFER_LEVEL
-selection_NOP	selectionStrategies/Selection_NOP.cpp	/^Selection_NOP * Selection_NOP::selection_NOP = 0;$/;"	m	class:Selection_NOP	file:
-selection_NOP	selectionStrategies/Selection_NOP.h	/^		static Selection_NOP * selection_NOP;$/;"	m	class:Selection_NOP
-selection_RANDOM	selectionStrategies/Selection_RANDOM.cpp	/^Selection_RANDOM * Selection_RANDOM::selection_RANDOM = 0;$/;"	m	class:Selection_RANDOM	file:
-selection_RANDOM	selectionStrategies/Selection_RANDOM.h	/^		static Selection_RANDOM * selection_RANDOM;$/;"	m	class:Selection_RANDOM
 selection_pwr_d	Power.h	/^    double selection_pwr_d;$/;"	m	class:Power
 selection_pwr_s	Power.h	/^    double selection_pwr_s;$/;"	m	class:Power
 selection_strategy	GlobalParams.cpp	/^string GlobalParams::selection_strategy;$/;"	m	class:GlobalParams	file:
 selection_strategy	GlobalParams.h	/^    static string selection_strategy;$/;"	m	struct:GlobalParams
-selection_strategy_pm	GlobalParams.h	/^    map<string, pair<double, double> > selection_strategy_pm;$/;"	m	struct:__anon4
+selection_strategy_pm	GlobalParams.h	/^    map<string, pair<double, double> > selection_strategy_pm;$/;"	m	struct:__anon8
 sender_id	DataStructs.h	/^    int sender_id;$/;"	m	struct:NoP_data
 sequence_length	DataStructs.h	/^    int sequence_length;$/;"	m	struct:Flit
 sequence_no	DataStructs.h	/^    int sequence_no;		\/\/ The sequence number of the flit inside the packet$/;"	m	struct:Flit
@@ -721,12 +630,13 @@ signalHandler	Main.cpp	/^void signalHandler( int signum )$/;"	f
 simulation_time	GlobalParams.cpp	/^int GlobalParams::simulation_time;$/;"	m	class:GlobalParams	file:
 simulation_time	GlobalParams.h	/^    static int simulation_time;$/;"	m	struct:GlobalParams
 size	DataStructs.h	/^    int size;$/;"	m	struct:Packet
-size	DataStructs.h	/^    int size;$/;"	m	struct:__anon10
+size	DataStructs.h	/^    int size;$/;"	m	struct:__anon4
 sleep_end_cycle	Power.h	/^    int sleep_end_cycle;$/;"	m	class:Power
 socket	Initiator.h	/^  tlm_utils::simple_initiator_socket<Initiator> socket;$/;"	m	struct:Initiator
 socket	Target.h	/^  tlm_utils::simple_target_socket<Target> socket;$/;"	m	struct:Target
 south	NoC.h	/^    sc_signal<T> south;$/;"	m	struct:sc_signal_NSWE
 south	NoC.h	/^    sc_signal<T> south;$/;"	m	struct:sc_signal_NSWEH
+src	GlobalTrafficHardcoding.h	/^  int src;			\/\/ ID of the source node (PE)$/;"	m	struct:HardcodedTrafficEntry
 src	GlobalTrafficTable.h	/^  int src;			\/\/ ID of the source node (PE)$/;"	m	struct:Communication
 src_id	DataStructs.h	/^    int src_id;$/;"	m	struct:Flit
 src_id	DataStructs.h	/^    int src_id;$/;"	m	struct:Packet
@@ -739,14 +649,18 @@ t_off	GlobalTrafficTable.h	/^  int t_off;			\/\/ Time (in cycles) at which activ
 t_on	GlobalTrafficTable.h	/^  int t_on;			\/\/ Time (in cycles) at which activity begins$/;"	m	struct:Communication
 t_period	GlobalTrafficTable.h	/^  int t_period;		        \/\/ Period after which activity starts again$/;"	m	struct:Communication
 targ_socket	Channel.h	/^  tlm_utils::multi_passthrough_target_socket<Channel>    targ_socket;$/;"	m	struct:Channel
-thread_process	Initiator.cpp	/^  void Initiator::thread_process()$/;"	f	class:Initiator
+thread_process	Initiator.cpp	/^void Initiator::thread_process()$/;"	f	class:Initiator
 tile2Hub	Utils.h	/^inline int tile2Hub(int id)$/;"	f
 tile2Port	Hub.cpp	/^int Hub::tile2Port(int id)$/;"	f	class:Hub
 tileToAntennaProcess	Hub.cpp	/^void Hub::tileToAntennaProcess()$/;"	f	class:Hub
 timestamp	DataStructs.h	/^    double timestamp;		\/\/ SC timestamp at packet generation$/;"	m	struct:Packet
 timestamp	DataStructs.h	/^    double timestamp;		\/\/ Unix timestamp at packet generation$/;"	m	struct:Flit
-toTileBufferSize	GlobalParams.h	/^    int toTileBufferSize;$/;"	m	struct:__anon2
+toTileBufferSize	GlobalParams.h	/^    int toTileBufferSize;$/;"	m	struct:__anon6
 to_hub	NoC.h	/^    sc_signal<T> to_hub;$/;"	m	struct:sc_signal_NSWEH
+toggleKthBit	NoC.cpp	/^inline int toggleKthBit(int n, int k) $/;"	f
+toggleKthBit	Router.cpp	/^inline int toggleKthBit(int n, int k)$/;"	f
+topology	GlobalParams.cpp	/^string GlobalParams::topology;$/;"	m	class:GlobalParams	file:
+topology	GlobalParams.h	/^    static string topology;$/;"	m	struct:GlobalParams
 total_power_s	Power.h	/^    double total_power_s;$/;"	m	class:Power
 total_received_flits	Stats.h	/^    unsigned int total_received_flits;$/;"	m	struct:CommHistory
 trace_filename	GlobalParams.cpp	/^string GlobalParams::trace_filename;$/;"	m	class:GlobalParams	file:
@@ -762,25 +676,27 @@ trafficTest	ProcessingElement.cpp	/^Packet ProcessingElement::trafficTest()$/;"	
 trafficTranspose1	ProcessingElement.cpp	/^Packet ProcessingElement::trafficTranspose1()$/;"	f	class:ProcessingElement
 trafficTranspose2	ProcessingElement.cpp	/^Packet ProcessingElement::trafficTranspose2()$/;"	f	class:ProcessingElement
 trafficULocal	ProcessingElement.cpp	/^Packet ProcessingElement::trafficULocal()$/;"	f	class:ProcessingElement
+traffic_at_cycle	GlobalTrafficHardcoding.cpp	/^vector < HardcodedTrafficEntry > const& GlobalTrafficHardcoding::traffic_at_cycle(int cycle) const {$/;"	f	class:GlobalTrafficHardcoding
 traffic_distribution	GlobalParams.cpp	/^string GlobalParams::traffic_distribution;$/;"	m	class:GlobalParams	file:
 traffic_distribution	GlobalParams.h	/^    static string traffic_distribution;$/;"	m	struct:GlobalParams
+traffic_hardcoded_filename	GlobalParams.cpp	/^string GlobalParams::traffic_hardcoded_filename;$/;"	m	class:GlobalParams	file:
+traffic_hardcoded_filename	GlobalParams.h	/^    static string traffic_hardcoded_filename;$/;"	m	struct:GlobalParams
+traffic_list	GlobalTrafficHardcoding.h	/^    vector < vector < HardcodedTrafficEntry > > traffic_list;$/;"	m	class:GlobalTrafficHardcoding
 traffic_table	GlobalTrafficTable.h	/^     vector < Communication > traffic_table;$/;"	m	class:GlobalTrafficTable
 traffic_table_filename	GlobalParams.cpp	/^string GlobalParams::traffic_table_filename;$/;"	m	class:GlobalParams	file:
 traffic_table_filename	GlobalParams.h	/^    static string traffic_table_filename;$/;"	m	struct:GlobalParams
-traffic_hardcoded_filename	GlobalParams.cpp	/^string GlobalParams::traffic_hardcoded_filename;$/;"	m	class:GlobalParams	file:
-traffic_hardcoded_filename	GlobalParams.h	/^    static string traffic_hardcoded_filename;$/;"	m	struct:GlobalParams
 trans	MM.h	/^    gp_t* trans;$/;"	m	struct:mm::access
-transceiver_biasing	GlobalParams.h	/^    pair<double, double> transceiver_biasing;$/;"	m	struct:__anon5
-transceiver_leakage	GlobalParams.h	/^    pair<double, double> transceiver_leakage;$/;"	m	struct:__anon5
+transceiver_biasing	GlobalParams.h	/^    pair<double, double> transceiver_biasing;$/;"	m	struct:__anon9
+transceiver_leakage	GlobalParams.h	/^    pair<double, double> transceiver_leakage;$/;"	m	struct:__anon9
 transceiver_rx_pwr_biasing	Power.h	/^    double transceiver_rx_pwr_biasing;$/;"	m	class:Power
 transceiver_rx_pwr_s	Power.h	/^    double transceiver_rx_pwr_s;$/;"	m	class:Power
 transceiver_tx_pwr_biasing	Power.h	/^    double transceiver_tx_pwr_biasing;$/;"	m	class:Power
 transceiver_tx_pwr_s	Power.h	/^    double transceiver_tx_pwr_s;$/;"	m	class:Power
-transmitter_attenuation_map	GlobalParams.h	/^    map<pair <int, int>, double> transmitter_attenuation_map;$/;"	m	struct:__anon5
+transmitter_attenuation_map	GlobalParams.h	/^    map<pair <int, int>, double> transmitter_attenuation_map;$/;"	m	struct:__anon9
 transport_dbg	Channel.cpp	/^  unsigned int Channel::transport_dbg(int id, tlm::tlm_generic_payload& trans)$/;"	f	class:Channel
 true_buffer	Buffer.h	/^    bool true_buffer;$/;"	m	class:Buffer
-txBufferSize	GlobalParams.h	/^    int txBufferSize;$/;"	m	struct:__anon2
-txChannels	GlobalParams.h	/^    vector<int> txChannels;$/;"	m	struct:__anon2
+txBufferSize	GlobalParams.h	/^    int txBufferSize;$/;"	m	struct:__anon6
+txChannels	GlobalParams.h	/^    vector<int> txChannels;$/;"	m	struct:__anon6
 txPowerManager	Hub.cpp	/^void Hub::txPowerManager()$/;"	f	class:Hub
 txProcess	ProcessingElement.cpp	/^void ProcessingElement::txProcess()$/;"	f	class:ProcessingElement
 txProcess	Router.cpp	/^void Router::txProcess()$/;"	f	class:Router
@@ -802,7 +718,7 @@ use_powermanager	GlobalParams.h	/^    static bool use_powermanager;$/;"	m	struct
 use_winoc	GlobalParams.cpp	/^bool GlobalParams::use_winoc;$/;"	m	class:GlobalParams	file:
 use_winoc	GlobalParams.h	/^    static bool use_winoc;$/;"	m	struct:GlobalParams
 valid	GlobalRoutingTable.h	/^    bool valid;$/;"	m	class:GlobalRoutingTable
-value	DataStructs.h	/^    double value;$/;"	m	struct:__anon7
+value	DataStructs.h	/^    double value;$/;"	m	struct:__anon1
 vc	ReservationTable.h	/^    int vc;$/;"	m	struct:TReservation
 vc_id	DataStructs.h	/^    int vc_id; \/\/ Virtual Channel$/;"	m	struct:Flit
 vc_id	DataStructs.h	/^    int vc_id;$/;"	m	struct:Packet
@@ -812,6 +728,8 @@ verbose_mode	GlobalParams.h	/^    static string verbose_mode;$/;"	m	struct:Globa
 warm_up_time	Stats.h	/^    double warm_up_time;$/;"	m	class:Stats
 west	NoC.h	/^    sc_signal<T> west;$/;"	m	struct:sc_signal_NSWE
 west	NoC.h	/^    sc_signal<T> west;$/;"	m	struct:sc_signal_NSWEH
+winoc_dst_hops	GlobalParams.cpp	/^int GlobalParams::winoc_dst_hops;$/;"	m	class:GlobalParams	file:
+winoc_dst_hops	GlobalParams.h	/^    static int winoc_dst_hops;$/;"	m	struct:GlobalParams
 wirelessDynamicRx	Power.cpp	/^void Power::wirelessDynamicRx()$/;"	f	class:Power
 wirelessSnooping	Power.cpp	/^void Power::wirelessSnooping()$/;"	f	class:Power
 wirelessTx	Power.cpp	/^void Power::wirelessTx(int src,int dst,int length)$/;"	f	class:Power
@@ -819,21 +737,5 @@ wireless_rx_pwr	Power.h	/^    double wireless_rx_pwr;$/;"	m	class:Power
 wireless_snooping	Power.h	/^    double wireless_snooping;$/;"	m	class:Power
 wonullstream	Utils.h	/^typedef basic_onullstream<wchar_t> wonullstream;$/;"	t
 x	DataStructs.h	/^    int x;			\/\/ X coordinate$/;"	m	class:Coord
-xy	routingAlgorithms/Routing_NEGATIVE_FIRST.cpp	/^RoutingAlgorithm * Routing_NEGATIVE_FIRST::xy = 0;$/;"	m	class:Routing_NEGATIVE_FIRST	file:
-xy	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^        static RoutingAlgorithm * xy;$/;"	m	class:Routing_NEGATIVE_FIRST
-xy	routingAlgorithms/Routing_NORTH_LAST.cpp	/^RoutingAlgorithm * Routing_NORTH_LAST::xy = 0;$/;"	m	class:Routing_NORTH_LAST	file:
-xy	routingAlgorithms/Routing_NORTH_LAST.h	/^        static RoutingAlgorithm * xy;$/;"	m	class:Routing_NORTH_LAST
-xy	routingAlgorithms/Routing_WEST_FIRST.cpp	/^RoutingAlgorithm * Routing_WEST_FIRST::xy = 0;$/;"	m	class:Routing_WEST_FIRST	file:
-xy	routingAlgorithms/Routing_WEST_FIRST.h	/^        static RoutingAlgorithm * xy;$/;"	m	class:Routing_WEST_FIRST
 y	DataStructs.h	/^    int y;			\/\/ Y coordinate$/;"	m	class:Coord
 ~Buffer	Buffer.h	/^    virtual ~ Buffer() {$/;"	f	class:Buffer
-~Routing_DYAD	routingAlgorithms/Routing_DYAD.h	/^		~Routing_DYAD(){};$/;"	f	class:Routing_DYAD
-~Routing_NEGATIVE_FIRST	routingAlgorithms/Routing_NEGATIVE_FIRST.h	/^		~Routing_NEGATIVE_FIRST(){};$/;"	f	class:Routing_NEGATIVE_FIRST
-~Routing_NORTH_LAST	routingAlgorithms/Routing_NORTH_LAST.h	/^		~Routing_NORTH_LAST(){};$/;"	f	class:Routing_NORTH_LAST
-~Routing_ODD_EVEN	routingAlgorithms/Routing_ODD_EVEN.h	/^		~Routing_ODD_EVEN(){};$/;"	f	class:Routing_ODD_EVEN
-~Routing_TABLE_BASED	routingAlgorithms/Routing_TABLE_BASED.h	/^		~Routing_TABLE_BASED(){};$/;"	f	class:Routing_TABLE_BASED
-~Routing_WEST_FIRST	routingAlgorithms/Routing_WEST_FIRST.h	/^		~Routing_WEST_FIRST(){};$/;"	f	class:Routing_WEST_FIRST
-~Routing_XY	routingAlgorithms/Routing_XY.h	/^		~Routing_XY(){};$/;"	f	class:Routing_XY
-~Selection_BUFFER_LEVEL	selectionStrategies/Selection_BUFFER_LEVEL.h	/^		~Selection_BUFFER_LEVEL(){};$/;"	f	class:Selection_BUFFER_LEVEL
-~Selection_NOP	selectionStrategies/Selection_NOP.h	/^		~Selection_NOP(){};$/;"	f	class:Selection_NOP
-~Selection_RANDOM	selectionStrategies/Selection_RANDOM.h	/^		~Selection_RANDOM(){};$/;"	f	class:Selection_RANDOM

--- a/src/tags
+++ b/src/tags
@@ -190,6 +190,7 @@ TRAFFIC_BUTTERFLY	GlobalParams.h	/^#define TRAFFIC_BUTTERFLY /;"	d
 TRAFFIC_HOTSPOT	GlobalParams.h	/^#define TRAFFIC_HOTSPOT /;"	d
 TRAFFIC_LOCAL	GlobalParams.h	/^#define TRAFFIC_LOCAL	/;"	d
 TRAFFIC_RANDOM	GlobalParams.h	/^#define TRAFFIC_RANDOM /;"	d
+TRAFFIC_HARDCODED	GlobalParams.h	/^#define TRAFFIC_HARDCODED /;"	d
 TRAFFIC_SHUFFLE	GlobalParams.h	/^#define TRAFFIC_SHUFFLE /;"	d
 TRAFFIC_TABLE_BASED	GlobalParams.h	/^#define TRAFFIC_TABLE_BASED /;"	d
 TRAFFIC_TRANSPOSE1	GlobalParams.h	/^#define TRAFFIC_TRANSPOSE1 /;"	d
@@ -766,6 +767,8 @@ traffic_distribution	GlobalParams.h	/^    static string traffic_distribution;$/;
 traffic_table	GlobalTrafficTable.h	/^     vector < Communication > traffic_table;$/;"	m	class:GlobalTrafficTable
 traffic_table_filename	GlobalParams.cpp	/^string GlobalParams::traffic_table_filename;$/;"	m	class:GlobalParams	file:
 traffic_table_filename	GlobalParams.h	/^    static string traffic_table_filename;$/;"	m	struct:GlobalParams
+traffic_hardcoded_filename	GlobalParams.cpp	/^string GlobalParams::traffic_hardcoded_filename;$/;"	m	class:GlobalParams	file:
+traffic_hardcoded_filename	GlobalParams.h	/^    static string traffic_hardcoded_filename;$/;"	m	struct:GlobalParams
 trans	MM.h	/^    gp_t* trans;$/;"	m	struct:mm::access
 transceiver_biasing	GlobalParams.h	/^    pair<double, double> transceiver_biasing;$/;"	m	struct:__anon5
 transceiver_leakage	GlobalParams.h	/^    pair<double, double> transceiver_leakage;$/;"	m	struct:__anon5


### PR DESCRIPTION
Currently, NOXIM only supports distribution based traffic. For those wanting to use this tool for power estimation of a pre-simulated workload, even table based routing falls short of producing the exact traffic patterns required.

This PR introduces the `TRAFFIC_HARDCODED` option (and `traffic_hardcoded_filename` argument). Traffic files are of the form:
```
<src> <dest>    # Traffic entry for current cycle
<src> <dest>    # Another entry for same cycle
-1              # End of cycle marker
<src> <dest>    # Traffic for next cycle
-1              # End of cycle
-1              # Empty cycle (no traffic)
-1              # Another empty cycle
<src> <dest>    # Traffic resumes
-1              # End of cycle
```
and are indexed by the local IDs of the processing elements.

The changes in this PR were the minimal required to make this work -- please let me know if I'm missing anything major, or if any of my changes are against the conventions of this repo.

Marking this WIP since although I've done enough implementation to make this work, I have questions to make sure if was implemented correctly.