### PR TITLE
Fix TRAFFIC_HOTSPOT: add hotspot case to parser and PE dispatcher

### DIFF
--- a/config_examples/default_config_hotspot.yaml
+++ b/config_examples/default_config_hotspot.yaml
@@ -186,7 +186,7 @@ probability_of_retransmission: 0.01
 #   TRAFFIC_SHUFFLE
 #   TRAFFIC_BUTTERFLY
 #   TRAFFIC_HARDCODED
-traffic_distribution: TRAFFIC_RANDOM
+traffic_distribution: TRAFFIC_HOTSPOT
 # when traffic table based is specified, use the following
 # configuration file
 traffic_table_filename: "t.txt"
@@ -194,5 +194,5 @@ traffic_table_filename: "t.txt"
 # configuration file
 traffic_hardcoded_filename: "t.txt"
 # Hotspot traffic example
-# Run with: ./bin/noxim -config config_examples/default_config_hotspot.yaml -power bin/power.yaml
+# Run with: ./bin/noxim -config config_examples/default_config_hotspot.yaml -traffic hotspot -hs 5 0.2 -power bin/power.yaml
 # Node 5 receives 20% of extra traffic

--- a/config_examples/default_config_hotspot.yaml
+++ b/config_examples/default_config_hotspot.yaml
@@ -1,0 +1,198 @@
+# Simple default config of a 4x4 mesh
+# Each parameter is overwritten when corresponding command line value is set
+#
+# NOC & WIRED CONFIGURATION
+#
+#
+# Topologies:
+#   MESH
+#   BUTTERFLY
+#   BASELINE
+#   OMEGA
+#
+#   BUTTERFLY, BASELINE, and OMEGA are Delta Network topologies
+# topology: MESH
+# X and Y mesh sizes
+mesh_dim_x: 4
+mesh_dim_y: 4
+# number of flits for each router buffer
+buffer_depth: 4
+# size of flits, in bits
+flit_size: 32
+# lenght in mm of router to hub connection
+r2h_link_length: 2.0
+# lenght in mm of router to router connection
+r2r_link_length: 1.0
+n_virtual_channels: 1
+
+# Routing algorithms:
+#   XY
+#   DELTA
+#   WEST_FIRST
+#   NORTH_LAST
+#   NEGATIVE_FIRST
+#   ODD_EVEN
+#   DYAD
+#   TABLE_BASED
+# Each of the above labels should match a corresponding
+# implementation in the routingAlgorithms source code directory
+routing_algorithm: XY
+routing_table_filename: ""
+
+# Routing specific parameters
+#   dyad_threshold: double
+dyad_threshold: 0.6
+
+# Selection Strategies:
+#   RANDOM
+#   BUFFER_LEVEL
+#   NOP
+# Each of the above labels should match a corresponding
+# implementation in the selectionStrategies source code directory
+selection_strategy: RANDOM
+
+#
+# WIRELESS CONFIGURATION
+#
+Hubs:
+    defaults:
+    # channels from which Hub can receive/transmit
+        rx_radio_channels: [0]
+        tx_radio_channels: [0]
+    # list of node tiles attached to the hub
+        attached_nodes: []
+    # size of buffers connecting the hub to tiles
+        to_tile_buffer_size: 4
+        from_tile_buffer_size: 4
+    # size of antenna tx/rx
+        rx_buffer_size: 4
+        tx_buffer_size: 4
+
+# for each hub, the same parameters specified above can be customized
+# If not specified, the above default values will be used
+# What is usually needed to be customized specifically for each hub is
+# the set of nodes that are connected to it. In this simple topology
+# we have 4 hubs (0-3) connected to the four nodes of the 2x2
+# sub-meshes
+
+    0:
+      attached_nodes: [0,1,4,5]
+
+    1:
+      attached_nodes: [2,3,6,7]
+
+    2:
+      attached_nodes: [8,9,12,13]
+
+    3:
+      attached_nodes: [10,11,14,15]
+
+# Transmission channels configuration
+# each channel modelizes the transmission over a given frequency that
+# can be used by a set of communicating hubs
+RadioChannels:
+    defaults:
+    # data rate in Gb/s affect the number of cycles required for a
+    # flit transmission
+        data_rate: 16
+    # bit error rate (CURRENTLY UNSUPPORTED)
+        ber: [0, 0]
+    # mac policies:
+
+    # who has the token releas only when a complete packet has
+    # been sent
+        #[TOKEN_PACKET]
+
+    # who has the token, release only after a fixed number of
+    # cycles, even no transmission is occurring
+        #[TOKEN_HOLD, num_hold_cycles]
+
+    # who has the token, holds the packet until needed for
+    # transmissions, until a max number of cycles is reached
+        #[TOKEN_MAX_HOLD, max_hold_cycles]
+        mac_policy: [TOKEN_PACKET]
+
+
+# SIMULATION PARAMETERS
+#
+clock_period_ps: 1000
+# duration of reset signal assertion, expressed in cycles
+reset_time: 1000
+# overal simulation lenght, expressed in cycles
+simulation_time: 10000
+# collect stats after a given number of cycles
+stats_warm_up_time: 1000
+# power breakdown, nodes communication details
+detailed: false
+# stop after a given amount of load has been processed
+max_volume_to_be_drained: 0
+show_buffer_stats: false
+
+# Winoc
+# enable wireless, when false, all wireless channel configuration is
+# ignored
+use_winoc: false
+# experimental power saving strategy
+use_wirxsleep: false
+
+# Verbosity level:
+#   VERBOSE_OFF
+#   VERBOSE_LOW
+#   VERBOSE_MEDIUM
+#   VERBOSE_HIGH
+verbose_mode: VERBOSE_OFF
+
+# Runtime logs:
+#   OFF
+#   ERROR
+#   WARN
+#   INFO
+#   DEBUG
+#   TRACE
+log_level: OFF
+log_file: ""
+log_to_stderr: true
+log_components: []
+
+# Optional stats export:
+#   text
+#   csv
+#   json
+stats_format: text
+stats_file: ""
+
+# Trace
+trace_mode: false
+trace_filename: ""
+#   basic: clock/reset + req/ack handshakes
+#   router: flits + NoP router signals
+#   buffers: buffer-full and free-slot signals
+#   wireless: hub/core wireless links + token-ring signals
+#   all: all of the above
+trace_scope: basic
+
+min_packet_size: 8
+max_packet_size: 8
+packet_injection_rate: 0.01
+probability_of_retransmission: 0.01
+
+# Traffic distribution:
+#   TRAFFIC_RANDOM
+#   TRAFFIC_TRANSPOSE1
+#   TRAFFIC_TRANSPOSE2
+#   TRAFFIC_HOTSPOT
+#   TRAFFIC_TABLE_BASED
+#   TRAFFIC_BIT_REVERSAL
+#   TRAFFIC_SHUFFLE
+#   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
+traffic_distribution: TRAFFIC_RANDOM
+# when traffic table based is specified, use the following
+# configuration file
+traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt"
+# Hotspot traffic example
+# Run with: ./bin/noxim -config config_examples/default_config_hotspot.yaml -power bin/power.yaml
+# Node 5 receives 20% of extra traffic

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -362,6 +362,7 @@ void showHelp(char selfname[])
          << "\t\tbitreversal\tBit-reversal traffic distribution" << endl
          << "\t\tbutterfly\tButterfly traffic distribution" << endl
          << "\t\tshuffle\t\tShuffle traffic distribution" << endl
+         << "\t\thotspot\t\tHotspot traffic distribution" << endl
          <<	"\t\ttable FILENAME\tTraffic Table Based traffic distribution with table in the specified file" << endl
          << "\t-hs ID P\t\tAdd node ID to hotspot nodes, with percentage P (0..1) (Only for 'random' traffic)" << endl
          << "\t-warmup N\t\tStart to collect statistics after N cycles" << endl

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -734,7 +734,9 @@ void parseCmdLine(int arg_num, char *arg_vet[])
 		} else if (!strcmp(traffic, "local")) {
 		    GlobalParams::traffic_distribution = TRAFFIC_LOCAL;
 		    GlobalParams::locality = atof(requireOptionValue(i, arg_num, arg_vet, "-traffic"));
-		}
+		} else if (!strcmp(traffic, "hotspot")) {
+    GlobalParams::traffic_distribution = TRAFFIC_HOTSPOT;
+}
 		else assert(false);
 	    } 
 	    else if (!strcmp(arg_vet[i], "-hs")) 

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -364,7 +364,7 @@ void showHelp(char selfname[])
          << "\t\tshuffle\t\tShuffle traffic distribution" << endl
          << "\t\thotspot\t\tHotspot traffic distribution" << endl
          <<	"\t\ttable FILENAME\tTraffic Table Based traffic distribution with table in the specified file" << endl
-         << "\t-hs ID P\t\tAdd node ID to hotspot nodes, with percentage P (0..1) (Only for 'random' traffic)" << endl
+         << "\t-hs ID P\t\tAdd node ID to hotspot nodes, with percentage P (0..1) (Only for 'random'/'hotspot' traffic)" << endl
          << "\t-warmup N\t\tStart to collect statistics after N cycles" << endl
          << "\t-seed N\t\t\tSet the seed of the random generator (default time())" << endl
          << "\t-detailed\t\tShow detailed statistics" << endl

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -161,6 +161,8 @@ bool ProcessingElement::canShot(Packet & packet)
 		    packet = trafficLocal();
         else if (GlobalParams::traffic_distribution == TRAFFIC_ULOCAL)
 		    packet = trafficULocal();
+         else if (GlobalParams::traffic_distribution == TRAFFIC_HOTSPOT)
+                    packet = trafficRandom();
         else {
             cout << "Invalid traffic distribution: " << GlobalParams::traffic_distribution << endl;
             exit(-1);


### PR DESCRIPTION
Fixes #109

## Problem
TRAFFIC_HOTSPOT was defined in GlobalParams.h but was not handled in:
1. ConfigurationManager.cpp — command line parser rejected "hotspot" argument
2. ProcessingElement.cpp — no case in traffic dispatcher, causing crash

## Fix
- Added "hotspot" case in ConfigurationManager.cpp parser
- Added TRAFFIC_HOTSPOT case in ProcessingElement.cpp dispatcher (routes to trafficRandom(), since hotspot nodes are already set via -hs flag)
- Added config_examples/default_config_hotspot.yaml as a worked example

## Testing
./bin/noxim -config config_examples/default_config_hotspot.yaml -traffic hotspot -hs 5 0.2 -power bin/power.yaml
Simulation completes successfully — 11000 cycles executed.