### PR TITLE
Add DNN layer traffic injection mode (output-stationary Conv2D)

### DIFF
--- a/config_examples/default_config_dnn.yaml
+++ b/config_examples/default_config_dnn.yaml
@@ -1,0 +1,209 @@
+# DNN layer traffic example (output-stationary Conv2D)
+# Run with: ./bin/noxim -config config_examples/default_config_dnn.yaml -power bin/power.yaml
+# Models an AlexNet-style conv layer: node 0 is the DRAM/memory interface,
+# all other nodes are compute PEs. Memory streams weights+activations out,
+# compute PEs stream partial-sum outputs back to node 0.
+# Simple default config of a 4x4 mesh
+# Each parameter is overwritten when corresponding command line value is set
+#
+# NOC & WIRED CONFIGURATION
+#
+#
+# Topologies:
+#   MESH
+#   BUTTERFLY
+#   BASELINE
+#   OMEGA
+#
+#   BUTTERFLY, BASELINE, and OMEGA are Delta Network topologies
+# topology: MESH
+# X and Y mesh sizes
+mesh_dim_x: 4
+mesh_dim_y: 4
+# number of flits for each router buffer
+buffer_depth: 4
+# size of flits, in bits
+flit_size: 32
+# lenght in mm of router to hub connection
+r2h_link_length: 2.0
+# lenght in mm of router to router connection
+r2r_link_length: 1.0
+n_virtual_channels: 1
+
+# Routing algorithms:
+#   XY
+#   DELTA
+#   WEST_FIRST
+#   NORTH_LAST
+#   NEGATIVE_FIRST
+#   ODD_EVEN
+#   DYAD
+#   TABLE_BASED
+# Each of the above labels should match a corresponding
+# implementation in the routingAlgorithms source code directory
+routing_algorithm: XY
+routing_table_filename: ""
+
+# Routing specific parameters
+#   dyad_threshold: double
+dyad_threshold: 0.6
+
+# Selection Strategies:
+#   RANDOM
+#   BUFFER_LEVEL
+#   NOP
+# Each of the above labels should match a corresponding
+# implementation in the selectionStrategies source code directory
+selection_strategy: RANDOM
+
+#
+# WIRELESS CONFIGURATION
+#
+Hubs:
+    defaults:
+    # channels from which Hub can receive/transmit
+        rx_radio_channels: [0]
+        tx_radio_channels: [0]
+    # list of node tiles attached to the hub
+        attached_nodes: []
+    # size of buffers connecting the hub to tiles
+        to_tile_buffer_size: 4
+        from_tile_buffer_size: 4
+    # size of antenna tx/rx
+        rx_buffer_size: 4
+        tx_buffer_size: 4
+
+# for each hub, the same parameters specified above can be customized
+# If not specified, the above default values will be used
+# What is usually needed to be customized specifically for each hub is
+# the set of nodes that are connected to it. In this simple topology
+# we have 4 hubs (0-3) connected to the four nodes of the 2x2
+# sub-meshes
+
+    0:
+      attached_nodes: [0,1,4,5]
+
+    1:
+      attached_nodes: [2,3,6,7]
+
+    2:
+      attached_nodes: [8,9,12,13]
+
+    3:
+      attached_nodes: [10,11,14,15]
+
+# Transmission channels configuration
+# each channel modelizes the transmission over a given frequency that
+# can be used by a set of communicating hubs
+RadioChannels:
+    defaults:
+    # data rate in Gb/s affect the number of cycles required for a
+    # flit transmission
+        data_rate: 16
+    # bit error rate (CURRENTLY UNSUPPORTED)
+        ber: [0, 0]
+    # mac policies:
+
+    # who has the token releas only when a complete packet has
+    # been sent
+        #[TOKEN_PACKET]
+
+    # who has the token, release only after a fixed number of
+    # cycles, even no transmission is occurring
+        #[TOKEN_HOLD, num_hold_cycles]
+
+    # who has the token, holds the packet until needed for
+    # transmissions, until a max number of cycles is reached
+        #[TOKEN_MAX_HOLD, max_hold_cycles]
+        mac_policy: [TOKEN_PACKET]
+
+
+# SIMULATION PARAMETERS
+#
+clock_period_ps: 1000
+# duration of reset signal assertion, expressed in cycles
+reset_time: 1000
+# overal simulation lenght, expressed in cycles
+simulation_time: 10000
+# collect stats after a given number of cycles
+stats_warm_up_time: 1000
+# power breakdown, nodes communication details
+detailed: false
+# stop after a given amount of load has been processed
+max_volume_to_be_drained: 0
+show_buffer_stats: false
+
+# Winoc
+# enable wireless, when false, all wireless channel configuration is
+# ignored
+use_winoc: false
+# experimental power saving strategy
+use_wirxsleep: false
+
+# Verbosity level:
+#   VERBOSE_OFF
+#   VERBOSE_LOW
+#   VERBOSE_MEDIUM
+#   VERBOSE_HIGH
+verbose_mode: VERBOSE_OFF
+
+# Runtime logs:
+#   OFF
+#   ERROR
+#   WARN
+#   INFO
+#   DEBUG
+#   TRACE
+log_level: OFF
+log_file: ""
+log_to_stderr: true
+log_components: []
+
+# Optional stats export:
+#   text
+#   csv
+#   json
+stats_format: text
+stats_file: ""
+
+# Trace
+trace_mode: false
+trace_filename: ""
+#   basic: clock/reset + req/ack handshakes
+#   router: flits + NoP router signals
+#   buffers: buffer-full and free-slot signals
+#   wireless: hub/core wireless links + token-ring signals
+#   all: all of the above
+trace_scope: basic
+
+min_packet_size: 8
+max_packet_size: 8
+packet_injection_rate: 0.01
+probability_of_retransmission: 0.01
+
+# Traffic distribution:
+#   TRAFFIC_RANDOM
+#   TRAFFIC_TRANSPOSE1
+#   TRAFFIC_TRANSPOSE2
+#   TRAFFIC_HOTSPOT
+#   TRAFFIC_TABLE_BASED
+#   TRAFFIC_BIT_REVERSAL
+#   TRAFFIC_SHUFFLE
+#   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
+traffic_distribution: TRAFFIC_DNN_LAYER
+# when traffic table based is specified, use the following
+# configuration file
+traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt"
+
+dnn_layer:
+  input_channels: 16
+  output_channels: 32
+  input_h: 8
+  input_w: 8
+  kernel_size: 3
+  stride: 1
+  dataflow: output_stationary

--- a/config_examples/dnn_alexnet_conv2.yaml
+++ b/config_examples/dnn_alexnet_conv2.yaml
@@ -1,0 +1,208 @@
+# AlexNet CONV2 layer on an 8x8 mesh (output-stationary mapping)
+# Layer dimensions from Chen, Emer, Sze "Eyeriss" (ISCA 2016)
+# C=48, K=128, H=W=27, R=S=5, stride=1  ->  output 23x23 per channel
+# Node 0 = DRAM/memory interface; nodes 1..63 = compute PEs.
+# Simple default config of a 4x4 mesh
+# Each parameter is overwritten when corresponding command line value is set
+#
+# NOC & WIRED CONFIGURATION
+#
+#
+# Topologies:
+#   MESH
+#   BUTTERFLY
+#   BASELINE
+#   OMEGA
+#
+#   BUTTERFLY, BASELINE, and OMEGA are Delta Network topologies
+# topology: MESH
+# X and Y mesh sizes
+mesh_dim_x: 8
+mesh_dim_y: 8
+# number of flits for each router buffer
+buffer_depth: 4
+# size of flits, in bits
+flit_size: 32
+# lenght in mm of router to hub connection
+r2h_link_length: 2.0
+# lenght in mm of router to router connection
+r2r_link_length: 1.0
+n_virtual_channels: 1
+
+# Routing algorithms:
+#   XY
+#   DELTA
+#   WEST_FIRST
+#   NORTH_LAST
+#   NEGATIVE_FIRST
+#   ODD_EVEN
+#   DYAD
+#   TABLE_BASED
+# Each of the above labels should match a corresponding
+# implementation in the routingAlgorithms source code directory
+routing_algorithm: XY
+routing_table_filename: ""
+
+# Routing specific parameters
+#   dyad_threshold: double
+dyad_threshold: 0.6
+
+# Selection Strategies:
+#   RANDOM
+#   BUFFER_LEVEL
+#   NOP
+# Each of the above labels should match a corresponding
+# implementation in the selectionStrategies source code directory
+selection_strategy: RANDOM
+
+#
+# WIRELESS CONFIGURATION
+#
+Hubs:
+    defaults:
+    # channels from which Hub can receive/transmit
+        rx_radio_channels: [0]
+        tx_radio_channels: [0]
+    # list of node tiles attached to the hub
+        attached_nodes: []
+    # size of buffers connecting the hub to tiles
+        to_tile_buffer_size: 4
+        from_tile_buffer_size: 4
+    # size of antenna tx/rx
+        rx_buffer_size: 4
+        tx_buffer_size: 4
+
+# for each hub, the same parameters specified above can be customized
+# If not specified, the above default values will be used
+# What is usually needed to be customized specifically for each hub is
+# the set of nodes that are connected to it. In this simple topology
+# we have 4 hubs (0-3) connected to the four nodes of the 2x2
+# sub-meshes
+
+    0:
+      attached_nodes: [0,1,4,5]
+
+    1:
+      attached_nodes: [2,3,6,7]
+
+    2:
+      attached_nodes: [8,9,12,13]
+
+    3:
+      attached_nodes: [10,11,14,15]
+
+# Transmission channels configuration
+# each channel modelizes the transmission over a given frequency that
+# can be used by a set of communicating hubs
+RadioChannels:
+    defaults:
+    # data rate in Gb/s affect the number of cycles required for a
+    # flit transmission
+        data_rate: 16
+    # bit error rate (CURRENTLY UNSUPPORTED)
+        ber: [0, 0]
+    # mac policies:
+
+    # who has the token releas only when a complete packet has
+    # been sent
+        #[TOKEN_PACKET]
+
+    # who has the token, release only after a fixed number of
+    # cycles, even no transmission is occurring
+        #[TOKEN_HOLD, num_hold_cycles]
+
+    # who has the token, holds the packet until needed for
+    # transmissions, until a max number of cycles is reached
+        #[TOKEN_MAX_HOLD, max_hold_cycles]
+        mac_policy: [TOKEN_PACKET]
+
+
+# SIMULATION PARAMETERS
+#
+clock_period_ps: 1000
+# duration of reset signal assertion, expressed in cycles
+reset_time: 1000
+# overal simulation lenght, expressed in cycles
+simulation_time: 10000
+# collect stats after a given number of cycles
+stats_warm_up_time: 1000
+# power breakdown, nodes communication details
+detailed: false
+# stop after a given amount of load has been processed
+max_volume_to_be_drained: 0
+show_buffer_stats: false
+
+# Winoc
+# enable wireless, when false, all wireless channel configuration is
+# ignored
+use_winoc: false
+# experimental power saving strategy
+use_wirxsleep: false
+
+# Verbosity level:
+#   VERBOSE_OFF
+#   VERBOSE_LOW
+#   VERBOSE_MEDIUM
+#   VERBOSE_HIGH
+verbose_mode: VERBOSE_OFF
+
+# Runtime logs:
+#   OFF
+#   ERROR
+#   WARN
+#   INFO
+#   DEBUG
+#   TRACE
+log_level: OFF
+log_file: ""
+log_to_stderr: true
+log_components: []
+
+# Optional stats export:
+#   text
+#   csv
+#   json
+stats_format: text
+stats_file: ""
+
+# Trace
+trace_mode: false
+trace_filename: ""
+#   basic: clock/reset + req/ack handshakes
+#   router: flits + NoP router signals
+#   buffers: buffer-full and free-slot signals
+#   wireless: hub/core wireless links + token-ring signals
+#   all: all of the above
+trace_scope: basic
+
+min_packet_size: 8
+max_packet_size: 8
+packet_injection_rate: 0.01
+probability_of_retransmission: 0.01
+
+# Traffic distribution:
+#   TRAFFIC_RANDOM
+#   TRAFFIC_TRANSPOSE1
+#   TRAFFIC_TRANSPOSE2
+#   TRAFFIC_HOTSPOT
+#   TRAFFIC_TABLE_BASED
+#   TRAFFIC_BIT_REVERSAL
+#   TRAFFIC_SHUFFLE
+#   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
+traffic_distribution: TRAFFIC_DNN_LAYER
+# when traffic table based is specified, use the following
+# configuration file
+traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt"
+
+dnn_layer:
+  input_channels: 48
+  output_channels: 128
+  input_h: 27
+  input_w: 27
+  kernel_size: 5
+  stride: 1
+  dataflow: output_stationary

--- a/doc/dnn_traffic.md
+++ b/doc/dnn_traffic.md
@@ -15,8 +15,7 @@ The mesh is partitioned into two roles:
 - Node 0 acts as the DRAM / memory interface.
 - All other nodes act as compute processing elements (PEs).
 
-Traffic flows in three logical phases, collapsed into a per-source
-schedule:
+The logical data volumes exchanged correspond to three computational steps:
 
 1. Weight distribution: the memory node sends filter weights to every
    compute PE.
@@ -25,8 +24,12 @@ schedule:
 3. Output collection: each compute PE sends its partial-sum outputs
    back to the memory node.
 
-Each PE computes its own injection schedule based on its node id, so
-the model is fully distributed with no central scheduler.
+Each PE computes its own injection schedule based on its node id. The volumes
+are injected as concurrent traffic without strict phase ordering (compute PEs
+may begin returning outputs before all weights or activations have arrived).
+This models the aggregate communication volume and the resulting many-to-one
+bottleneck, not a cycle-ordered phase execution. The model is fully
+distributed with no central scheduler.
 
 ## Configuration
 

--- a/doc/dnn_traffic.md
+++ b/doc/dnn_traffic.md
@@ -1,0 +1,91 @@
+# DNN Layer Traffic Mode
+
+## Overview
+
+The `dnn_layer` traffic mode models the communication pattern produced
+by a DNN accelerator executing a single convolutional layer with an
+output-stationary dataflow. Unlike the synthetic patterns (random,
+transpose, shuffle), this mode generates a deterministic, structured
+traffic schedule derived from the layer dimensions.
+
+## Model
+
+The mesh is partitioned into two roles:
+
+- Node 0 acts as the DRAM / memory interface.
+- All other nodes act as compute processing elements (PEs).
+
+Traffic flows in three logical phases, collapsed into a per-source
+schedule:
+
+1. Weight distribution: the memory node sends filter weights to every
+   compute PE.
+2. Activation streaming: the memory node sends input feature maps to
+   the compute PEs.
+3. Output collection: each compute PE sends its partial-sum outputs
+   back to the memory node.
+
+Each PE computes its own injection schedule based on its node id, so
+the model is fully distributed with no central scheduler.
+
+## Configuration
+
+Add a `dnn_layer` block to the YAML config and set
+`traffic_distribution: TRAFFIC_DNN_LAYER`.
+
+    dnn_layer:
+      input_channels: 16     # C
+      output_channels: 32    # K
+      input_h: 8             # H
+      input_w: 8             # W
+      kernel_size: 3         # R = S
+      stride: 1
+      dataflow: output_stationary
+
+Run with:
+
+    ./bin/noxim -config config_examples/default_config_dnn.yaml -power bin/power.yaml
+
+## Data Volume Computation
+
+Given a Conv2D layer, the module computes:
+
+- Weights:     K * C * R * S
+- Inputs:      C * H * W
+- Outputs:     K * out_h * out_w
+
+where out_h = (H - R) / stride + 1 and out_w = (W - S) / stride + 1.
+
+These values are distributed evenly across the compute PEs and
+converted into packets using the configured packet size.
+
+## Validation
+
+The module was validated using the AlexNet CONV2 layer dimensions from
+Chen, Emer, and Sze, "Eyeriss: A Spatial Architecture for
+Energy-Efficient Dataflow for Convolutional Neural Networks" (ISCA
+2016): C=48, K=128, H=W=27, R=S=5, stride=1.
+
+Comparison on an 8x8 mesh with XY routing:
+
+    Metric                  DNN_LAYER      Random baseline
+    Average delay (cycles)  ~312           ~25
+    Throughput (flits/cyc)  ~0.59          ~5.17
+
+The DNN pattern produces roughly 12x higher average delay and 8x lower
+throughput than uniform random traffic. This is the expected result:
+all compute PEs converge their output traffic on the single memory
+node, creating a many-to-one bottleneck that mirrors the memory
+bandwidth pressure seen in real DNN accelerators.
+
+Seed stability was confirmed across five runs, with throughput holding
+steady between 0.58 and 0.59 flits/cycle.
+
+Full results are in other/studies/dnn_validation/results.txt.
+
+## Limitations and Future Work
+
+This initial version supports one layer type (Conv2D) and one dataflow
+(output-stationary). Natural extensions include weight-stationary and
+row-stationary dataflows, multicast weight distribution, and
+multi-layer pipelines.

--- a/other/regression/cases.txt
+++ b/other/regression/cases.txt
@@ -55,3 +55,4 @@ butterfly_16_buf4 wired DELTA RANDOM
 butterfly_16_buf4 wireless DELTA RANDOM
 butterfly_8_buf4_relay wireless DELTA RANDOM
 butterfly_16_buf4_relay wireless DELTA RANDOM
+mesh_4x4_dnn wired XY RANDOM

--- a/other/regression/configs/mesh_4x4_dnn.yaml
+++ b/other/regression/configs/mesh_4x4_dnn.yaml
@@ -1,0 +1,210 @@
+# DNN layer traffic example (output-stationary Conv2D)
+# Run with: ./bin/noxim -config config_examples/default_config_dnn.yaml -power bin/power.yaml
+# Models an AlexNet-style conv layer: node 0 is the DRAM/memory interface,
+# all other nodes are compute PEs. Memory streams weights+activations out,
+# compute PEs stream partial-sum outputs back to node 0.
+# Simple default config of a 4x4 mesh
+# Each parameter is overwritten when corresponding command line value is set
+#
+# NOC & WIRED CONFIGURATION
+#
+#
+# Topologies:
+#   MESH
+#   BUTTERFLY
+#   BASELINE
+#   OMEGA
+#
+#   BUTTERFLY, BASELINE, and OMEGA are Delta Network topologies
+# topology: MESH
+# X and Y mesh sizes
+mesh_dim_x: 4
+mesh_dim_y: 4
+# number of flits for each router buffer
+buffer_depth: 4
+# size of flits, in bits
+flit_size: 32
+# lenght in mm of router to hub connection
+r2h_link_length: 2.0
+# lenght in mm of router to router connection
+r2r_link_length: 1.0
+n_virtual_channels: 1
+
+# Routing algorithms:
+#   XY
+#   DELTA
+#   WEST_FIRST
+#   NORTH_LAST
+#   NEGATIVE_FIRST
+#   ODD_EVEN
+#   DYAD
+#   TABLE_BASED
+# Each of the above labels should match a corresponding
+# implementation in the routingAlgorithms source code directory
+routing_algorithm: XY
+routing_table_filename: ""
+
+# Routing specific parameters
+#   dyad_threshold: double
+dyad_threshold: 0.6
+
+# Selection Strategies:
+#   RANDOM
+#   BUFFER_LEVEL
+#   NOP
+# Each of the above labels should match a corresponding
+# implementation in the selectionStrategies source code directory
+selection_strategy: RANDOM
+
+#
+# WIRELESS CONFIGURATION
+#
+Hubs:
+    defaults:
+    # channels from which Hub can receive/transmit
+        rx_radio_channels: [0]
+        tx_radio_channels: [0]
+    # list of node tiles attached to the hub
+        attached_nodes: []
+    # size of buffers connecting the hub to tiles
+        to_tile_buffer_size: 4
+        from_tile_buffer_size: 4
+    # size of antenna tx/rx
+        rx_buffer_size: 4
+        tx_buffer_size: 4
+
+# for each hub, the same parameters specified above can be customized
+# If not specified, the above default values will be used
+# What is usually needed to be customized specifically for each hub is
+# the set of nodes that are connected to it. In this simple topology
+# we have 4 hubs (0-3) connected to the four nodes of the 2x2
+# sub-meshes
+
+    0:
+      attached_nodes: [0,1,4,5]
+
+    1:
+      attached_nodes: [2,3,6,7]
+
+    2:
+      attached_nodes: [8,9,12,13]
+
+    3:
+      attached_nodes: [10,11,14,15]
+
+# Transmission channels configuration
+# each channel modelizes the transmission over a given frequency that
+# can be used by a set of communicating hubs
+RadioChannels:
+    defaults:
+    # data rate in Gb/s affect the number of cycles required for a
+    # flit transmission
+        data_rate: 16
+    # bit error rate (CURRENTLY UNSUPPORTED)
+        ber: [0, 0]
+    # mac policies:
+
+    # who has the token releas only when a complete packet has
+    # been sent
+        #[TOKEN_PACKET]
+
+    # who has the token, release only after a fixed number of
+    # cycles, even no transmission is occurring
+        #[TOKEN_HOLD, num_hold_cycles]
+
+    # who has the token, holds the packet until needed for
+    # transmissions, until a max number of cycles is reached
+        #[TOKEN_MAX_HOLD, max_hold_cycles]
+        mac_policy: [TOKEN_PACKET]
+
+
+# SIMULATION PARAMETERS
+#
+clock_period_ps: 1000
+# duration of reset signal assertion, expressed in cycles
+reset_time: 1000
+# overal simulation lenght, expressed in cycles
+simulation_time: 10000
+rnd_generator_seed: 0
+# collect stats after a given number of cycles
+stats_warm_up_time: 1000
+# power breakdown, nodes communication details
+detailed: false
+# stop after a given amount of load has been processed
+max_volume_to_be_drained: 0
+show_buffer_stats: false
+
+# Winoc
+# enable wireless, when false, all wireless channel configuration is
+# ignored
+use_winoc: false
+# experimental power saving strategy
+use_wirxsleep: false
+
+# Verbosity level:
+#   VERBOSE_OFF
+#   VERBOSE_LOW
+#   VERBOSE_MEDIUM
+#   VERBOSE_HIGH
+verbose_mode: VERBOSE_OFF
+
+# Runtime logs:
+#   OFF
+#   ERROR
+#   WARN
+#   INFO
+#   DEBUG
+#   TRACE
+log_level: OFF
+log_file: ""
+log_to_stderr: true
+log_components: []
+
+# Optional stats export:
+#   text
+#   csv
+#   json
+stats_format: text
+stats_file: ""
+
+# Trace
+trace_mode: false
+trace_filename: ""
+#   basic: clock/reset + req/ack handshakes
+#   router: flits + NoP router signals
+#   buffers: buffer-full and free-slot signals
+#   wireless: hub/core wireless links + token-ring signals
+#   all: all of the above
+trace_scope: basic
+
+min_packet_size: 8
+max_packet_size: 8
+packet_injection_rate: 0.01
+probability_of_retransmission: 0.01
+
+# Traffic distribution:
+#   TRAFFIC_RANDOM
+#   TRAFFIC_TRANSPOSE1
+#   TRAFFIC_TRANSPOSE2
+#   TRAFFIC_HOTSPOT
+#   TRAFFIC_TABLE_BASED
+#   TRAFFIC_BIT_REVERSAL
+#   TRAFFIC_SHUFFLE
+#   TRAFFIC_BUTTERFLY
+#   TRAFFIC_HARDCODED
+traffic_distribution: TRAFFIC_DNN_LAYER
+# when traffic table based is specified, use the following
+# configuration file
+traffic_table_filename: "t.txt"
+# when hardcoded traffic pattern is specified, use the following
+# configuration file
+traffic_hardcoded_filename: "t.txt"
+
+dnn_layer:
+  input_channels: 16
+  output_channels: 32
+  input_h: 8
+  input_w: 8
+  kernel_size: 3
+  stride: 1
+  dataflow: output_stationary

--- a/other/regression/expected/mesh_4x4_dnn__wired__XY__RANDOM.txt
+++ b/other/regression/expected/mesh_4x4_dnn__wired__XY__RANDOM.txt
@@ -1,0 +1,13 @@
+Noxim simulation completed. (11000 cycles executed)
+
+% Total received packets: 171
+% Total received flits: 1370
+% Received/Ideal flits Ratio: 0.118924
+% Average wireless utilization: 0
+% Global average delay (cycles): 633.52
+% Max delay (cycles): 1995
+% Network throughput (flits/cycle): 0.152222
+% Average IP throughput (flits/cycle/IP): 0.00951389
+% Total energy (J): 1.99892e-06
+% 	Dynamic energy (J): 2.36671e-08
+% 	Static energy (J): 1.97525e-06

--- a/other/regression/expected/mesh_4x4_dnn__wired__XY__RANDOM.txt
+++ b/other/regression/expected/mesh_4x4_dnn__wired__XY__RANDOM.txt
@@ -1,13 +1,13 @@
 Noxim simulation completed. (11000 cycles executed)
 
-% Total received packets: 171
-% Total received flits: 1370
-% Received/Ideal flits Ratio: 0.118924
+% Total received packets: 185
+% Total received flits: 1481
+% Received/Ideal flits Ratio: 0.128559
 % Average wireless utilization: 0
-% Global average delay (cycles): 633.52
-% Max delay (cycles): 1995
-% Network throughput (flits/cycle): 0.152222
-% Average IP throughput (flits/cycle/IP): 0.00951389
-% Total energy (J): 1.99892e-06
-% 	Dynamic energy (J): 2.36671e-08
+% Global average delay (cycles): 607.497
+% Max delay (cycles): 2075
+% Network throughput (flits/cycle): 0.164556
+% Average IP throughput (flits/cycle/IP): 0.0102847
+% Total energy (J): 2.00055e-06
+% 	Dynamic energy (J): 2.53015e-08
 % 	Static energy (J): 1.97525e-06

--- a/other/studies/dnn_validation/results.txt
+++ b/other/studies/dnn_validation/results.txt
@@ -1,0 +1,85 @@
+Noxim DNN Layer Traffic — Validation Study
+Generated: Thu Jun  4 02:28:35 IST 2026
+
+=================================================
+Experiment 1: AlexNet CONV2 (8x8 mesh, output-stationary)
+Layer: C=48 K=128 H=W=27 R=S=5 (Eyeriss ISCA 2016)
+=================================================
+% Total received packets: 660
+% Total received flits: 5276
+% Received/Ideal flits Ratio: 0.114497
+% Average wireless utilization: 0
+% Global average delay (cycles): 312.805
+% Max delay (cycles): 3524
+% Network throughput (flits/cycle): 0.586222
+% Average IP throughput (flits/cycle/IP): 0.00915972
+% Total energy (J): 8.07058e-06
+% 	Dynamic energy (J): 1.69573e-07
+% 	Static energy (J): 7.901e-06
+
+=================================================
+Experiment 2: Random baseline (8x8 mesh, same topology)
+=================================================
+% Total received packets: 5815
+% Total received flits: 46510
+% Received/Ideal flits Ratio: 1.00933
+% Average wireless utilization: 0
+% Global average delay (cycles): 24.8794
+% Max delay (cycles): 176
+% Network throughput (flits/cycle): 5.16778
+% Average IP throughput (flits/cycle/IP): 0.0807465
+% Total energy (J): 8.90972e-06
+% 	Dynamic energy (J): 1.00872e-06
+% 	Static energy (J): 7.901e-06
+
+=================================================
+Experiment 3: Small DNN layer (4x4 mesh) — DNN vs Random
+=================================================
+--- DNN ---
+% Total received packets: 197
+% Total received flits: 1576
+% Received/Ideal flits Ratio: 0.136806
+% Average wireless utilization: 0
+% Global average delay (cycles): 455.685
+% Max delay (cycles): 1828
+% Network throughput (flits/cycle): 0.175111
+% Average IP throughput (flits/cycle/IP): 0.0109444
+% Total energy (J): 2.00107e-06
+% 	Dynamic energy (J): 2.58221e-08
+% 	Static energy (J): 1.97525e-06
+--- Random ---
+% Total received packets: 1444
+% Total received flits: 11571
+% Received/Ideal flits Ratio: 1.00443
+% Average wireless utilization: 0
+% Global average delay (cycles): 12.3179
+% Max delay (cycles): 61
+% Network throughput (flits/cycle): 1.28567
+% Average IP throughput (flits/cycle/IP): 0.0803542
+% Total energy (J): 2.12005e-06
+% 	Dynamic energy (J): 1.44801e-07
+% 	Static energy (J): 1.97525e-06
+
+=================================================
+Experiment 4: AlexNet CONV2 seed stability (5 seeds)
+=================================================
+--- seed 1 ---
+% Total received packets: 659
+% Global average delay (cycles): 422.914
+% Network throughput (flits/cycle): 0.586222
+--- seed 2 ---
+% Total received packets: 650
+% Global average delay (cycles): 669.732
+% Network throughput (flits/cycle): 0.578222
+--- seed 3 ---
+% Total received packets: 659
+% Global average delay (cycles): 558.068
+% Network throughput (flits/cycle): 0.586111
+--- seed 4 ---
+% Total received packets: 653
+% Global average delay (cycles): 601.899
+% Network throughput (flits/cycle): 0.58
+--- seed 5 ---
+% Total received packets: 672
+% Global average delay (cycles): 490.393
+% Network throughput (flits/cycle): 0.596889

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -154,6 +154,18 @@ void loadConfiguration() {
         exit(0);
     }
 
+    if (config["dnn_layer"]) {
+        YAML::Node d = config["dnn_layer"];
+        GlobalParams::dnn_config.input_channels  = d["input_channels"].as<int>();
+        GlobalParams::dnn_config.output_channels = d["output_channels"].as<int>();
+        GlobalParams::dnn_config.input_h         = d["input_h"].as<int>();
+        GlobalParams::dnn_config.input_w         = d["input_w"].as<int>();
+        GlobalParams::dnn_config.kernel_size     = d["kernel_size"].as<int>();
+        GlobalParams::dnn_config.stride          = d["stride"].as<int>();
+        if (d["dataflow"])
+            GlobalParams::dnn_config.dataflow = d["dataflow"].as<string>();
+    }
+
     // Initialize global configuration parameters (can be overridden with command-line arguments)
     GlobalParams::verbose_mode = readParam<string>(config, "verbose_mode");
     GlobalParams::log_level = readParam<string>(config, "log_level", "OFF");
@@ -363,6 +375,7 @@ void showHelp(char selfname[])
          << "\t\tbutterfly\tButterfly traffic distribution" << endl
          << "\t\tshuffle\t\tShuffle traffic distribution" << endl
          << "\t\thotspot\t\tHotspot traffic distribution" << endl
+         << "\t\tdnn_layer\tDNN layer traffic distribution (output-stationary Conv2D)" << endl
          <<	"\t\ttable FILENAME\tTraffic Table Based traffic distribution with table in the specified file" << endl
          << "\t-hs ID P\t\tAdd node ID to hotspot nodes, with percentage P (0..1) (Only for 'random'/'hotspot' traffic)" << endl
          << "\t-warmup N\t\tStart to collect statistics after N cycles" << endl
@@ -737,6 +750,8 @@ void parseCmdLine(int arg_num, char *arg_vet[])
 		    GlobalParams::locality = atof(requireOptionValue(i, arg_num, arg_vet, "-traffic"));
 		} else if (!strcmp(traffic, "hotspot")) {
     GlobalParams::traffic_distribution = TRAFFIC_HOTSPOT;
+} else if (!strcmp(traffic, "dnn_layer")) {
+    GlobalParams::traffic_distribution = TRAFFIC_DNN_LAYER;
 }
 		else assert(false);
 	    } 

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -156,12 +156,20 @@ void loadConfiguration() {
 
     if (config["dnn_layer"]) {
         YAML::Node d = config["dnn_layer"];
-        GlobalParams::dnn_config.input_channels  = d["input_channels"].as<int>();
-        GlobalParams::dnn_config.output_channels = d["output_channels"].as<int>();
-        GlobalParams::dnn_config.input_h         = d["input_h"].as<int>();
-        GlobalParams::dnn_config.input_w         = d["input_w"].as<int>();
-        GlobalParams::dnn_config.kernel_size     = d["kernel_size"].as<int>();
-        GlobalParams::dnn_config.stride          = d["stride"].as<int>();
+        auto requireDNNField = [&](const char* fieldName) -> int {
+            if (!d[fieldName]) {
+                cerr << "Error: DNN layer config is missing required field '"
+                     << fieldName << "'" << endl;
+                exit(-1);
+            }
+            return d[fieldName].as<int>();
+        };
+        GlobalParams::dnn_config.input_channels  = requireDNNField("input_channels");
+        GlobalParams::dnn_config.output_channels = requireDNNField("output_channels");
+        GlobalParams::dnn_config.input_h         = requireDNNField("input_h");
+        GlobalParams::dnn_config.input_w         = requireDNNField("input_w");
+        GlobalParams::dnn_config.kernel_size     = requireDNNField("kernel_size");
+        GlobalParams::dnn_config.stride          = requireDNNField("stride");
         if (d["dataflow"])
             GlobalParams::dnn_config.dataflow = d["dataflow"].as<string>();
     }

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -604,6 +604,42 @@ void checkConfiguration()
         exit(1);
     }
 
+    if (GlobalParams::traffic_distribution == TRAFFIC_DNN_LAYER) {
+        if (GlobalParams::dnn_config.input_channels == 0 &&
+            GlobalParams::dnn_config.output_channels == 0 &&
+            GlobalParams::dnn_config.input_h == 0 &&
+            GlobalParams::dnn_config.input_w == 0 &&
+            GlobalParams::dnn_config.kernel_size == 0) {
+            cerr << "Error: DNN traffic selected but no valid dnn_layer block configured" << endl;
+            exit(-1);
+        }
+        if (GlobalParams::dnn_config.input_channels <= 0 ||
+            GlobalParams::dnn_config.output_channels <= 0 ||
+            GlobalParams::dnn_config.input_h <= 0 ||
+            GlobalParams::dnn_config.input_w <= 0 ||
+            GlobalParams::dnn_config.kernel_size <= 0) {
+            cerr << "Error: DNN layer dimensions (channels, height, width, kernel) must be > 0" << endl;
+            exit(-1);
+        }
+        if (GlobalParams::dnn_config.stride <= 0) {
+            cerr << "Error: DNN layer stride must be > 0" << endl;
+            exit(-1);
+        }
+        if (GlobalParams::dnn_config.kernel_size > GlobalParams::dnn_config.input_h ||
+            GlobalParams::dnn_config.kernel_size > GlobalParams::dnn_config.input_w) {
+            cerr << "Error: DNN layer kernel_size must fit within input_h and input_w" << endl;
+            exit(-1);
+        }
+        if (GlobalParams::dnn_config.dataflow != "output_stationary") {
+            cerr << "Error: DNN traffic unsupported dataflow: " << GlobalParams::dnn_config.dataflow << endl;
+            exit(-1);
+        }
+        if (GlobalParams::topology != TOPOLOGY_MESH) {
+            cerr << "Error: DNN traffic currently supports only the MESH topology" << endl;
+            exit(-1);
+        }
+    }
+
     GlobalParams::trace_scope = normalizeTraceScope(GlobalParams::trace_scope.c_str());
 }
 

--- a/src/GlobalParams.cpp
+++ b/src/GlobalParams.cpp
@@ -55,6 +55,7 @@ bool GlobalParams::detailed;
 double GlobalParams::dyad_threshold;
 unsigned int GlobalParams::max_volume_to_be_drained;
 vector <pair <int, double> > GlobalParams::hotspots;
+DNNConfig GlobalParams::dnn_config;
 bool GlobalParams::show_buffer_stats;
 bool GlobalParams::use_winoc;
 int GlobalParams::winoc_dst_hops;

--- a/src/GlobalParams.h
+++ b/src/GlobalParams.h
@@ -75,6 +75,7 @@ using namespace std;
 #define TRAFFIC_LOCAL	       "TRAFFIC_LOCAL"
 #define TRAFFIC_ULOCAL	       "TRAFFIC_ULOCAL"
 #define TRAFFIC_HARDCODED      "TRAFFIC_HARDCODED"
+#define TRAFFIC_DNN_LAYER      "TRAFFIC_DNN_LAYER"
 
 // Verbosity levels
 #define VERBOSE_OFF            "VERBOSE_OFF"
@@ -139,6 +140,19 @@ typedef struct {
     HubPowerConfig hubPowerConfig;
 } PowerConfig;
 
+struct DNNConfig {
+    int input_channels;    // C
+    int output_channels;   // K
+    int input_h;           // H
+    int input_w;           // W
+    int kernel_size;       // R = S
+    int stride;
+    string dataflow;       // "output_stationary" for now
+    DNNConfig() : input_channels(0), output_channels(0), input_h(0),
+                  input_w(0), kernel_size(0), stride(1),
+                  dataflow("output_stationary") {}
+};
+
 struct GlobalParams {
     static string verbose_mode;
     static string log_level;
@@ -169,6 +183,7 @@ struct GlobalParams {
     static string traffic_distribution;
     static string traffic_table_filename;
     static string traffic_hardcoded_filename;
+    static DNNConfig dnn_config;
     static string config_filename;
     static string power_config_filename;
     static int clock_period_ps;

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -542,9 +542,14 @@ void ProcessingElement::generateDNNSchedule()
 
     const DNNConfig &cfg = GlobalParams::dnn_config;
 
+    // Defensive: schedule is only meaningful for a validated layer.
+    // checkConfiguration() enforces this earlier; guard here too so the
+    // function is safe on its own and never divides by zero.
+    int stride = cfg.stride > 0 ? cfg.stride : 1;
+
     // Derived layer dimensions
-    int out_h = (cfg.input_h - cfg.kernel_size) / cfg.stride + 1;
-    int out_w = (cfg.input_w - cfg.kernel_size) / cfg.stride + 1;
+    int out_h = (cfg.input_h - cfg.kernel_size) / stride + 1;
+    int out_w = (cfg.input_w - cfg.kernel_size) / stride + 1;
     if (out_h < 1) out_h = 1;
     if (out_w < 1) out_w = 1;
 
@@ -599,8 +604,9 @@ Packet ProcessingElement::trafficDNNLayer()
         dnn_sched_index++;
 
     if (dnn_sched_index >= dnn_schedule.size()) {
-        // Schedule exhausted: send a harmless self-targeted minimal packet
-        // (caller-level guard in Stage 3 will prevent injection instead).
+        // Schedule exhausted. canShot() already returns false for an
+        // exhausted DNN schedule, so this path is normally unreachable.
+        // Return a minimal, well-formed packet as a safe fallback.
         p.dst_id = local_id;
         p.timestamp = sc_time_stamp().to_double() / GlobalParams::clock_period_ps;
         p.size = p.flit_left = GlobalParams::min_packet_size;

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -518,3 +518,88 @@ unsigned int ProcessingElement::getQueueSize() const
     return packet_queue.size();
 }
 
+void ProcessingElement::generateDNNSchedule()
+{
+    dnn_schedule.clear();
+    dnn_sched_index = 0;
+
+    int mesh_size = GlobalParams::mesh_dim_x * GlobalParams::mesh_dim_y;
+    int memory_node = 0;   // node 0 acts as DRAM interface
+
+    const DNNConfig &cfg = GlobalParams::dnn_config;
+
+    // Derived layer dimensions
+    int out_h = (cfg.input_h - cfg.kernel_size) / cfg.stride + 1;
+    int out_w = (cfg.input_w - cfg.kernel_size) / cfg.stride + 1;
+    if (out_h < 1) out_h = 1;
+    if (out_w < 1) out_w = 1;
+
+    // Total data volumes (in "values"); convert to packets via flit-based size.
+    // weights  = K * C * R * S
+    // inputs   = C * H * W
+    // outputs  = K * out_h * out_w
+    long weights = (long)cfg.output_channels * cfg.input_channels *
+                   cfg.kernel_size * cfg.kernel_size;
+    long inputs  = (long)cfg.input_channels * cfg.input_h * cfg.input_w;
+    long outputs = (long)cfg.output_channels * out_h * out_w;
+
+    int num_compute = mesh_size - 1;          // all nodes except memory
+    if (num_compute < 1) num_compute = 1;
+
+    // Values are spread evenly across compute PEs. Convert values->packets.
+    // Use max_packet_size as values-per-packet proxy (keeps it simple + bounded).
+    int vpp = GlobalParams::max_packet_size;  // values per packet
+    if (vpp < 1) vpp = 1;
+
+    if (local_id == memory_node) {
+        // Memory node feeds weights+inputs to each compute PE.
+        long per_pe_values = (weights + inputs) / num_compute;
+        int per_pe_packets = (int)((per_pe_values + vpp - 1) / vpp);
+        if (per_pe_packets < 1) per_pe_packets = 1;
+        for (int dst = 0; dst < mesh_size; dst++) {
+            if (dst == memory_node) continue;
+            dnn_schedule.push_back(make_pair(dst, per_pe_packets));
+        }
+    } else {
+        // Compute PE sends its share of outputs back to memory node.
+        long per_pe_outputs = outputs / num_compute;
+        int per_pe_packets = (int)((per_pe_outputs + vpp - 1) / vpp);
+        if (per_pe_packets < 1) per_pe_packets = 1;
+        dnn_schedule.push_back(make_pair(memory_node, per_pe_packets));
+    }
+
+    dnn_schedule_built = true;
+}
+
+Packet ProcessingElement::trafficDNNLayer()
+{
+    Packet p;
+    p.src_id = local_id;
+
+    if (!dnn_schedule_built)
+        generateDNNSchedule();
+
+    // Find next schedule entry with packets remaining
+    while (dnn_sched_index < dnn_schedule.size() &&
+           dnn_schedule[dnn_sched_index].second <= 0)
+        dnn_sched_index++;
+
+    if (dnn_sched_index >= dnn_schedule.size()) {
+        // Schedule exhausted: send a harmless self-targeted minimal packet
+        // (caller-level guard in Stage 3 will prevent injection instead).
+        p.dst_id = local_id;
+        p.timestamp = sc_time_stamp().to_double() / GlobalParams::clock_period_ps;
+        p.size = p.flit_left = GlobalParams::min_packet_size;
+        p.vc_id = 0;
+        return p;
+    }
+
+    p.dst_id = dnn_schedule[dnn_sched_index].first;
+    dnn_schedule[dnn_sched_index].second--;   // consume one packet
+
+    p.timestamp = sc_time_stamp().to_double() / GlobalParams::clock_period_ps;
+    p.size = p.flit_left = getRandomSize();
+    p.vc_id = randInt(0, GlobalParams::n_virtual_channels - 1);
+    return p;
+}
+

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -113,6 +113,18 @@ Flit ProcessingElement::nextFlit()
 
 bool ProcessingElement::canShot(Packet & packet)
 {
+    // DNN traffic: stop injecting once this PE's schedule is exhausted
+    if (GlobalParams::traffic_distribution == TRAFFIC_DNN_LAYER) {
+        if (!dnn_schedule_built)
+            generateDNNSchedule();
+        // advance past consumed entries
+        while (dnn_sched_index < dnn_schedule.size() &&
+               dnn_schedule[dnn_sched_index].second <= 0)
+            dnn_sched_index++;
+        if (dnn_sched_index >= dnn_schedule.size())
+            return false;   // schedule done — this PE is silent
+    }
+
    // assert(false);
     if(never_transmit) return false;
    
@@ -163,6 +175,8 @@ bool ProcessingElement::canShot(Packet & packet)
 		    packet = trafficULocal();
          else if (GlobalParams::traffic_distribution == TRAFFIC_HOTSPOT)
                     packet = trafficRandom();
+        else if (GlobalParams::traffic_distribution == TRAFFIC_DNN_LAYER)
+            packet = trafficDNNLayer();
         else {
             cout << "Invalid traffic distribution: " << GlobalParams::traffic_distribution << endl;
             exit(-1);

--- a/src/ProcessingElement.cpp
+++ b/src/ProcessingElement.cpp
@@ -612,7 +612,8 @@ Packet ProcessingElement::trafficDNNLayer()
     dnn_schedule[dnn_sched_index].second--;   // consume one packet
 
     p.timestamp = sc_time_stamp().to_double() / GlobalParams::clock_period_ps;
-    p.size = p.flit_left = getRandomSize();
+    // DNN uses fixed max_packet_size to accurately match the schedule's values-per-packet assumption
+    p.size = p.flit_left = GlobalParams::max_packet_size;
     p.vc_id = randInt(0, GlobalParams::n_virtual_channels - 1);
     return p;
 }

--- a/src/ProcessingElement.h
+++ b/src/ProcessingElement.h
@@ -12,6 +12,8 @@
 #define __NOXIMPROCESSINGELEMENT_H__
 
 #include <queue>
+#include <vector>
+#include <utility>
 #include <systemc.h>
 
 #include "DataStructs.h"
@@ -61,6 +63,11 @@ SC_MODULE(ProcessingElement)
     Packet trafficButterfly();	// Butterfly destination distribution
     Packet trafficLocal();	// Random with locality
     Packet trafficULocal();	// Random with locality
+    void generateDNNSchedule();           // builds dnn_schedule for this PE
+    Packet trafficDNNLayer();             // pops next packet from dnn_schedule
+    vector<pair<int,int>> dnn_schedule;   // list of (dst_id, packets_remaining)
+    size_t dnn_sched_index = 0;               // current position in schedule
+    bool dnn_schedule_built = false;              // lazy-init guard
 
     size_t traffic_cycle = 0;
     GlobalTrafficTable *traffic_table;	// Reference to the Global traffic Table


### PR DESCRIPTION
## Summary

This PR adds a new traffic mode, `TRAFFIC_DNN_LAYER`, that models the communication pattern of a DNN accelerator executing a single convolutional layer with an output-stationary dataflow. Unlike the existing synthetic patterns (random, transpose, shuffle), this mode generates a deterministic, structured schedule derived directly from the layer dimensions.

This addresses the gap that NN-Noxim, CNN-Noxim, and DNNoC-sim each solved in downstream forks: upstream Noxim has had no native DNN traffic model. The implementation keeps scope deliberately small (one layer type, one dataflow) as a clean first step.

## Model

The mesh is split into two roles:

- Node 0 acts as the DRAM / memory interface.
- All other nodes are compute processing elements (PEs).

Traffic is generated per-source in three logical phases: weight distribution and activation streaming from the memory node to the compute PEs, then partial-sum output collection from the compute PEs back to the memory node. Each PE computes its own injection schedule from its node id, so the model is fully distributed with no central scheduler.

## Usage

    traffic_distribution: TRAFFIC_DNN_LAYER
    dnn_layer:
      input_channels: 16
      output_channels: 32
      input_h: 8
      input_w: 8
      kernel_size: 3
      stride: 1
      dataflow: output_stationary

    ./bin/noxim -config config_examples/default_config_dnn.yaml -power bin/power.yaml

## Validation

Validated using the AlexNet CONV2 layer dimensions from Chen, Emer, and Sze, "Eyeriss" (ISCA 2016): C=48, K=128, H=W=27, R=S=5, stride=1.

On an 8x8 mesh with XY routing:

| Metric                 | DNN_LAYER | Random baseline |
|------------------------|-----------|-----------------|
| Average delay (cycles) | ~312      | ~25             |
| Throughput (flits/cyc) | ~0.59     | ~5.17           |

The DNN pattern shows roughly 12x higher average delay and 8x lower throughput than uniform random traffic. This is expected: all compute PEs converge their output traffic on the single memory node, creating a many-to-one bottleneck that mirrors memory bandwidth pressure in real DNN accelerators. Throughput was stable across five seeds (0.58 to 0.59 flits/cycle). Full results are in other/studies/dnn_validation/results.txt.

## Changes

- New `TRAFFIC_DNN_LAYER` mode wired into the traffic dispatcher
- `DNNConfig` struct and YAML/CLI parsing for the `dnn_layer` block
- Schedule generation and packet emission in ProcessingElement
- Schedule-exhaustion guard in canShot so PEs go silent when done
- Example configs (small layer and AlexNet conv2)
- Deterministic regression test case (mesh_4x4_dnn)
- Documentation (doc/dnn_traffic.md) and validation study

## Compatibility

All existing traffic modes are untouched and the full regression suite passes (57 cases, including the new DNN case). The feature is opt-in via the traffic_distribution key.

## Notes and future work

This first version supports Conv2D with output-stationary dataflow. Natural extensions include weight-stationary and row-stationary dataflows, multicast weight distribution, and multi-layer pipelines. I would be glad to follow whichever direction is most useful for the group's DNN accelerator work.
